### PR TITLE
Add index on dbo.Logs (JobId)

### DIFF
--- a/Sloth.Sql/dbo/Tables/Logs.sql
+++ b/Sloth.Sql/dbo/Tables/Logs.sql
@@ -28,3 +28,7 @@ GO
 CREATE NONCLUSTERED INDEX [IX_Logs_JobNameId]
     ON [dbo].[Logs]([JobName] ASC, [JobId] ASC);
 
+
+GO
+CREATE NONCLUSTERED INDEX [IX_Logs_JobId]
+    ON [dbo].[Logs] ([JobId] ASC)


### PR DESCRIPTION
Issue #112 
An index is needed on Logs.JobId in order to avoid a table scan when joining against Kfs and Scrubber job tables.