### PR TITLE
Eliminate local evaluations in EFCore queries

### DIFF
--- a/Sloth.Api/Controllers/TransactionsController.cs
+++ b/Sloth.Api/Controllers/TransactionsController.cs
@@ -155,8 +155,7 @@ namespace Sloth.Api.Controllers
 
             // find source
             var source = await _context.Sources.FirstOrDefaultAsync(s =>
-                string.Equals(s.Name, transaction.Source, StringComparison.InvariantCultureIgnoreCase)
-                && string.Equals(s.Type, transaction.SourceType, StringComparison.InvariantCultureIgnoreCase));
+                s.Name == transaction.Source && s.Type == transaction.SourceType);
 
             if (source == null)
             {


### PR DESCRIPTION
Fixes a regression caused by PR #125 which impacts issue  #115.

EF Core 3.x no longer supports local query evaluation. MS recommends either refactoring queries to not need local evaluation or make local evaluation explicit by using `AsEnumerable()`.