### PR TITLE
Save the blobs

### DIFF
--- a/Sloth.Core/Domain/Blob.cs
+++ b/Sloth.Core/Domain/Blob.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+using Sloth.Core.Domain;
+
+namespace Sloth.Core.Models
+{
+    public class Blob
+    {
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+
+        [Display(Name = "File Name")]
+        public string FileName { get; set; }
+
+        public string Uri { get; set; }
+
+        public string Description { get; set; }
+
+        public string Container { get; set; }
+
+        [Display(Name = "Media Type")]
+        public string MediaType { get; set; }
+
+        [Display(Name = "Uploaded Date")]
+        public DateTime UploadedDate { get; set; }
+
+        public IList<KfsScrubberUploadJobRecord> KfsScrubberUploadJobRecords { get; set; }
+
+        public IList<CybersourceBankReconcileJobBlob> CybersourceBankReconcileJobBlobs { get; set; }
+
+        public static void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Blob>()
+                .HasMany(blob => blob.KfsScrubberUploadJobRecords)
+                .WithOne(r => r.Blob)
+                .HasForeignKey(r => r.BlobId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            modelBuilder.Entity<Blob>()
+                .HasMany(blob => blob.CybersourceBankReconcileJobBlobs)
+                .WithOne(r => r.Blob)
+                .HasForeignKey(r => r.BlobId)
+                .OnDelete(DeleteBehavior.Restrict);
+        }
+    }
+}

--- a/Sloth.Core/Domain/Blob.cs
+++ b/Sloth.Core/Domain/Blob.cs
@@ -25,16 +25,16 @@ namespace Sloth.Core.Models
         [Display(Name = "Uploaded Date")]
         public DateTime UploadedDate { get; set; }
 
-        public IList<KfsScrubberUploadJobRecord> KfsScrubberUploadJobRecords { get; set; }
+        public IList<Scrubber> Scrubbers { get; set; }
 
         public IList<CybersourceBankReconcileJobBlob> CybersourceBankReconcileJobBlobs { get; set; }
 
         public static void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<Blob>()
-                .HasMany(blob => blob.KfsScrubberUploadJobRecords)
-                .WithOne(r => r.Blob)
-                .HasForeignKey(r => r.BlobId)
+                .HasMany(blob => blob.Scrubbers)
+                .WithOne(s => s.Blob)
+                .HasForeignKey(s => s.BlobId)
                 .OnDelete(DeleteBehavior.Restrict);
 
             modelBuilder.Entity<Blob>()

--- a/Sloth.Core/Domain/CybersourceBankReconcileJobBlob.cs
+++ b/Sloth.Core/Domain/CybersourceBankReconcileJobBlob.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Sloth.Core.Models;
+
+namespace Sloth.Core.Domain
+{
+    public class CybersourceBankReconcileJobBlob
+    {
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+
+        public string IntegrationId { get; set; }
+
+        public Integration Integration { get; set; }
+
+        public string CybersourceBankReconcileJobRecordId { get; set; }
+
+        public CybersourceBankReconcileJobRecord CybersourceBankReconcileJobRecord { get; set; }
+
+        public string BlobId { get; set; }
+
+        public Blob Blob { get; set; }
+
+    }
+}

--- a/Sloth.Core/Domain/CybersourceBankReconcileJobRecord.cs
+++ b/Sloth.Core/Domain/CybersourceBankReconcileJobRecord.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using Microsoft.EntityFrameworkCore;
+using Sloth.Core.Domain;
 
 namespace Sloth.Core.Models
 {
@@ -12,6 +13,8 @@ namespace Sloth.Core.Models
         public DateTime ProcessedDate { get; set; }
 
         public IList<Transaction> Transactions { get; set; }
+
+        public IList<CybersourceBankReconcileJobBlob> CybersourceBankReconcileJobBlobs { get; set; }
 
         public static void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -25,6 +28,12 @@ namespace Sloth.Core.Models
                 .HasMany(r => r.Transactions)
                 .WithOne(t => t.CybersourceBankReconcileJob)
                 .HasForeignKey(t => t.CybersourceBankReconcileJobRecordId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            modelBuilder.Entity<CybersourceBankReconcileJobRecord>()
+                .HasMany(blob => blob.CybersourceBankReconcileJobBlobs)
+                .WithOne(r => r.CybersourceBankReconcileJobRecord)
+                .HasForeignKey(r => r.CybersourceBankReconcileJobRecordId)
                 .OnDelete(DeleteBehavior.Restrict);
         }
     }

--- a/Sloth.Core/Domain/Integration.cs
+++ b/Sloth.Core/Domain/Integration.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
+using Sloth.Core.Domain;
 
 namespace Sloth.Core.Models
 {
@@ -32,6 +34,9 @@ namespace Sloth.Core.Models
 
         public string HoldingAccount { get; set; }
 
+        public IList<CybersourceBankReconcileJobBlob> CybersourceBankReconcileJobBlobs { get; set; }
+
+
         protected internal static void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<Integration>()
@@ -42,6 +47,12 @@ namespace Sloth.Core.Models
             modelBuilder.Entity<Integration>()
                 .HasOne(i => i.Source)
                 .WithMany()
+                .OnDelete(DeleteBehavior.Restrict);
+
+            modelBuilder.Entity<Integration>()
+                .HasMany(i => i.CybersourceBankReconcileJobBlobs)
+                .WithOne(b => b.Integration)
+                .HasForeignKey(b => b.IntegrationId)
                 .OnDelete(DeleteBehavior.Restrict);
         }
     }

--- a/Sloth.Core/Domain/KfsScrubberUploadJobRecord.cs
+++ b/Sloth.Core/Domain/KfsScrubberUploadJobRecord.cs
@@ -9,6 +9,10 @@ namespace Sloth.Core.Models
     {
         public IList<Transaction> Transactions { get; set; }
 
+        public string BlobId { get; set; }
+
+        public Blob Blob { get; set; }
+
         public static void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<KfsScrubberUploadJobRecord>()

--- a/Sloth.Core/Domain/Scrubber.cs
+++ b/Sloth.Core/Domain/Scrubber.cs
@@ -37,5 +37,11 @@ namespace Sloth.Core.Models
         [MinLength(1)]
         [Required]
         public IList<Transaction> Transactions { get; set; }
+
+        public string BlobId { get; set; }
+
+        public Blob Blob { get; set; }
+
+
     }
 }

--- a/Sloth.Core/Jobs/KfsScrubberUploadJob.cs
+++ b/Sloth.Core/Jobs/KfsScrubberUploadJob.cs
@@ -70,9 +70,11 @@ namespace Sloth.Core.Jobs
                         log.Information("Uploading {filename}", filename);
                         var username = source.KfsFtpUsername;
                         var passwordKeyName = source.KfsFtpPasswordKeyName;
-                        var uri = await _kfsScrubberService.UploadScrubber(scrubber, filename, username,
+                        var blob = await _kfsScrubberService.UploadScrubber(scrubber, filename, username,
                             passwordKeyName, log);
-                        scrubber.Uri = uri?.AbsoluteUri ?? "";
+                        scrubber.Uri = blob?.Uri ?? ""; //TODO: remove Uri from scrubber table after ensureing data is in Blob table
+                        scrubber.Blob = blob;
+                        scrubber.BlobId = blob?.Id;
 
                         // persist scrubber uri
                         _context.Scrubbers.Add(scrubber);

--- a/Sloth.Core/Services/StorageService.cs
+++ b/Sloth.Core/Services/StorageService.cs
@@ -29,9 +29,9 @@ namespace Sloth.Core.Services
 
         public async Task GetBlobAsync(Stream stream, string containerName, string blobName)
         {
-            var container = await GetBlobContainerAsync(containerName);
-            var blob = container.GetBlockBlobClient(blobName);
-            await blob.DownloadToAsync(stream);
+            var containerClient = await GetBlobContainerAsync(containerName);
+            var blobClient = containerClient.GetBlockBlobClient(blobName);
+            await blobClient.DownloadToAsync(stream);
         }
 
         public Task GetBlobAsync(Stream stream, Uri uri)
@@ -42,19 +42,19 @@ namespace Sloth.Core.Services
 
         public async Task<Uri> PutBlobAsync(Stream stream, string containerName, string blobName)
         {
-            var container = await GetBlobContainerAsync(containerName);
-            var blob = container.GetBlockBlobClient(blobName);
-            await blob.UploadAsync(stream);
+            var containerClient = await GetBlobContainerAsync(containerName);
+            var blobClient = containerClient.GetBlockBlobClient(blobName);
+            await blobClient.UploadAsync(stream);
 
-            return blob.Uri;
+            return blobClient.Uri;
         }
 
         private async Task<BlobContainerClient> GetBlobContainerAsync(string containerName)
         {
-            var client = _blobServiceClient.GetBlobContainerClient(containerName);
-            await client.CreateIfNotExistsAsync();
+            var containerClient = _blobServiceClient.GetBlobContainerClient(containerName);
+            await containerClient.CreateIfNotExistsAsync();
 
-            return client;
+            return containerClient;
         }
 
     }

--- a/Sloth.Core/Services/StorageService.cs
+++ b/Sloth.Core/Services/StorageService.cs
@@ -6,13 +6,13 @@ using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
 using Microsoft.Extensions.Options;
 using Sloth.Core.Configuration;
+using Sloth.Core.Models;
 
 namespace Sloth.Core.Services
 {
     public interface IStorageService
     {
-        Task GetBlobAsync(Stream stream, string containerName, string blobName);
-        Task GetBlobAsync(Stream stream, Uri uri);
+        Task<Stream> GetBlobAsync(string containerName, string blobName);
         Task<Uri> PutBlobAsync(Stream stream, string container, string filepath);
     }
 
@@ -27,17 +27,13 @@ namespace Sloth.Core.Services
             _blobServiceClient = new BlobServiceClient(connectionString);
         }
 
-        public async Task GetBlobAsync(Stream stream, string containerName, string blobName)
+        public async Task<Stream> GetBlobAsync(string containerName, string blobName)
         {
+            var stream = new MemoryStream();
             var containerClient = await GetBlobContainerAsync(containerName);
             var blobClient = containerClient.GetBlockBlobClient(blobName);
             await blobClient.DownloadToAsync(stream);
-        }
-
-        public Task GetBlobAsync(Stream stream, Uri uri)
-        {
-            var blobUriBuilder = new BlobUriBuilder(uri);
-            return GetBlobAsync(stream, blobUriBuilder.BlobContainerName, blobUriBuilder.BlobName);
+            return stream;
         }
 
         public async Task<Uri> PutBlobAsync(Stream stream, string containerName, string blobName)
@@ -57,5 +53,59 @@ namespace Sloth.Core.Services
             return containerClient;
         }
 
+    }
+
+    public static class StorageServiceExtensions
+    {
+        public static Task<Stream> GetBlobAsync(this IStorageService storageService, Uri uri)
+        {
+            var blobUriBuilder = new BlobUriBuilder(uri);
+            return storageService.GetBlobAsync(blobUriBuilder.BlobContainerName, blobUriBuilder.BlobName);
+        }
+
+        public static Task<Stream> GetBlobAsync(this IStorageService storageService, string uri)
+        {
+            return storageService.GetBlobAsync(new Uri(uri));
+        }
+
+        public static Task<Stream> GetBlobAsync(this IStorageService storageService, Blob blob)
+        {
+            return storageService.GetBlobAsync(new Uri(blob.Uri));
+        }
+
+        public static async Task<Blob> PutBlobAsync(this IStorageService storageService, Stream stream, Blob blob)
+        {
+            var uri = await storageService.PutBlobAsync(stream, blob.Container, blob.FileName);
+            blob.Uri = uri.AbsoluteUri;
+            blob.UploadedDate = DateTime.UtcNow;
+            return blob;
+        }
+
+        public static Task<Blob> PutBlobAsync(this IStorageService storageService, string localFilePath, Blob blob)
+        {
+            var stream = File.OpenRead(localFilePath);
+            return storageService.PutBlobAsync(stream, blob);
+        }
+
+        public static async Task<Blob> PutBlobAsync(this IStorageService storageService, Stream stream,
+            string container, string name, string desctiption, string mediaType)
+        {
+            var blob = new Blob
+            {
+                FileName = name,
+                Description = desctiption,
+                Container = container,
+                MediaType = mediaType,
+            };
+            await storageService.PutBlobAsync(stream, blob);
+            return blob;
+        }
+
+        public static Task<Blob> PutBlobAsync(this IStorageService storageService, string localFilePath,
+            string container, string name, string desctiption, string mediaType)
+        {
+            var stream = File.OpenRead(localFilePath);
+            return storageService.PutBlobAsync(stream, container, name, desctiption, mediaType);
+        }
     }
 }

--- a/Sloth.Core/SlothDbContext.cs
+++ b/Sloth.Core/SlothDbContext.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
+using Sloth.Core.Domain;
 using Sloth.Core.Models;
 
 namespace Sloth.Core
@@ -40,6 +41,10 @@ namespace Sloth.Core
         public DbSet<LogMessage> Logs { get; set; }
 
         public DbSet<WebHook> WebHooks { get; set; }
+
+        public DbSet<Blob> Blobs { get; set; }
+
+        public DbSet<CybersourceBankReconcileJobBlob> CybersourceBankReconcileJobBlobs { get; set; }
 
         public async Task<string> GetNextKfsTrackingNumber(DbTransaction transaction = null)
         {
@@ -132,6 +137,7 @@ namespace Sloth.Core
             LogMessage.OnModelCreating(modelBuilder);
             CybersourceBankReconcileJobRecord.OnModelCreating(modelBuilder);
             KfsScrubberUploadJobRecord.OnModelCreating(modelBuilder);
+            Blob.OnModelCreating(modelBuilder);
         }
     }
 }

--- a/Sloth.Sql/Sloth.Sql.sqlproj
+++ b/Sloth.Sql/Sloth.Sql.sqlproj
@@ -92,5 +92,7 @@
     <Build Include="dbo\Tables\KfsScrubberUploadJobRecords.sql" />
     <Build Include="dbo\Sequences\Document_Number_Seq.sql" />
     <Build Include="dbo\Tables\WebHooks.sql" />
+    <Build Include="dbo\Tables\Blobs.sql" />
+    <Build Include="dbo\Tables\CybersourceBankReconcileJobBlobs.sql" />
   </ItemGroup>
 </Project>

--- a/Sloth.Sql/dbo/Tables/Blobs.sql
+++ b/Sloth.Sql/dbo/Tables/Blobs.sql
@@ -1,0 +1,22 @@
+CREATE TABLE [dbo].[Blobs]
+(
+    [Id] NVARCHAR(450) NOT NULL PRIMARY KEY, 
+    [FileName] NVARCHAR(450) NOT NULL, 
+    [Uri] NVARCHAR(450) NOT NULL, 
+    [Description] NVARCHAR(450) NOT NULL, 
+    [Container] NVARCHAR(450) NOT NULL, 
+    [MediaType] NVARCHAR(450) NOT NULL, 
+    [Uploaded] DATETIME2 NOT NULL
+)
+
+GO
+
+CREATE INDEX [IX_Blobs_FileName] ON [dbo].[Blobs] ([FileName] ASC)
+
+GO
+
+CREATE INDEX [IX_Blobs_Uploaded] ON [dbo].[Blobs] ([Uploaded] ASC)
+
+GO
+
+CREATE INDEX [IX_Blobs_Uri] ON [dbo].[Blobs] ([Uri] ASC)

--- a/Sloth.Sql/dbo/Tables/CybersourceBankReconcileJobBlobs.sql
+++ b/Sloth.Sql/dbo/Tables/CybersourceBankReconcileJobBlobs.sql
@@ -1,0 +1,22 @@
+CREATE TABLE [dbo].[CybersourceBankReconcileJobBlobs]
+(
+    [Id] NVARCHAR(450) NOT NULL PRIMARY KEY, 
+    [CybersourceBankReconcileJobRecordId] NVARCHAR(450) NOT NULL, 
+    [IntegrationId] NVARCHAR(450) NOT NULL, 
+    [BlobId] NVARCHAR(450) NOT NULL, 
+    CONSTRAINT [FK_CybersourceBankReconcileJobBlobs_CybersourceBankReconcileJobRecords] FOREIGN KEY ([CybersourceBankReconcileJobRecordId]) REFERENCES [CybersourceBankReconcileJobRecords]([Id]), 
+    CONSTRAINT [FK_CybersourceBankReconcileJobBlobs_Integrations] FOREIGN KEY ([IntegrationId]) REFERENCES [Integrations]([Id]), 
+    CONSTRAINT [FK_CybersourceBankReconcileJobBlobs_Blobs] FOREIGN KEY ([BlobId]) REFERENCES [Blobs]([Id])
+)
+
+GO
+
+CREATE INDEX [IX_CybersourceBankReconcileJobBlobs_CybersourceBankReconcileJobRecordId] ON [dbo].[CybersourceBankReconcileJobBlobs] ([CybersourceBankReconcileJobRecordId])
+
+GO
+
+CREATE INDEX [IX_CybersourceBankReconcileJobBlobs_IntegrationId] ON [dbo].[CybersourceBankReconcileJobBlobs] ([IntegrationId])
+
+GO
+
+CREATE INDEX [IX_CybersourceBankReconcileJobBlobs_BlobId] ON [dbo].[CybersourceBankReconcileJobBlobs] ([BlobId])

--- a/Sloth.Sql/dbo/Tables/KfsScrubberUploadJobRecords.sql
+++ b/Sloth.Sql/dbo/Tables/KfsScrubberUploadJobRecords.sql
@@ -3,6 +3,12 @@ CREATE TABLE [dbo].[KfsScrubberUploadJobRecords] (
     [Name]          NVARCHAR (MAX) NULL,
     [RanOn]         DATETIME2 (7)  NOT NULL,
     [Status]        NVARCHAR (MAX) NULL,
-    CONSTRAINT [PK_KfsScrubberUploadJobRecords] PRIMARY KEY CLUSTERED ([Id] ASC)
+    [BlobId] NVARCHAR(450) NULL, 
+    CONSTRAINT [PK_KfsScrubberUploadJobRecords] PRIMARY KEY CLUSTERED ([Id] ASC), 
+    CONSTRAINT [FK_KfsScrubberUploadJobRecords_Blobs] FOREIGN KEY ([BlobId]) REFERENCES [Blobs]([Id])
 );
 
+
+GO
+
+CREATE INDEX [IX_KfsScrubberUploadJobRecords_BlobId] ON [dbo].[KfsScrubberUploadJobRecords] ([BlobId])

--- a/Sloth.Sql/dbo/Tables/KfsScrubberUploadJobRecords.sql
+++ b/Sloth.Sql/dbo/Tables/KfsScrubberUploadJobRecords.sql
@@ -3,12 +3,9 @@ CREATE TABLE [dbo].[KfsScrubberUploadJobRecords] (
     [Name]          NVARCHAR (MAX) NULL,
     [RanOn]         DATETIME2 (7)  NOT NULL,
     [Status]        NVARCHAR (MAX) NULL,
-    [BlobId] NVARCHAR(450) NULL, 
     CONSTRAINT [PK_KfsScrubberUploadJobRecords] PRIMARY KEY CLUSTERED ([Id] ASC), 
-    CONSTRAINT [FK_KfsScrubberUploadJobRecords_Blobs] FOREIGN KEY ([BlobId]) REFERENCES [Blobs]([Id])
 );
 
 
 GO
 
-CREATE INDEX [IX_KfsScrubberUploadJobRecords_BlobId] ON [dbo].[KfsScrubberUploadJobRecords] ([BlobId])

--- a/Sloth.Sql/dbo/Tables/Scrubbers.sql
+++ b/Sloth.Sql/dbo/Tables/Scrubbers.sql
@@ -1,11 +1,13 @@
-﻿CREATE TABLE [dbo].[Scrubbers] (
+CREATE TABLE [dbo].[Scrubbers] (
     [Id]                  NVARCHAR (450) NOT NULL,
     [BatchDate]           DATETIME2 (7)  NOT NULL,
     [BatchSequenceNumber] INT            NOT NULL,
     [SourceId]            NVARCHAR (450) NOT NULL,
     [Uri]                 NVARCHAR (MAX) NULL,
+    [BlobId]              NVARCHAR(450) NULL, 
     CONSTRAINT [PK_Scrubbers] PRIMARY KEY CLUSTERED ([Id] ASC),
-    CONSTRAINT [FK_Scrubbers_Sources_SourceId] FOREIGN KEY ([SourceId]) REFERENCES [dbo].[Sources] ([Id]) ON DELETE CASCADE
+    CONSTRAINT [FK_Scrubbers_Sources_SourceId] FOREIGN KEY ([SourceId]) REFERENCES [dbo].[Sources] ([Id]) ON DELETE CASCADE,
+    CONSTRAINT [FK_Scrubbers_Blobs_BlobId] FOREIGN KEY ([BlobId]) REFERENCES [Blobs]([Id])
 );
 
 
@@ -14,6 +16,8 @@
 
 
 GO
-CREATE NONCLUSTERED INDEX [IX_Scrubbers_SourceId]
-    ON [dbo].[Scrubbers]([SourceId] ASC);
+CREATE NONCLUSTERED INDEX [IX_Scrubbers_SourceId] ON [dbo].[Scrubbers]([SourceId] ASC);
 
+GO
+
+CREATE NONCLUSTERED INDEX [IX_Scrubbers_BlobId] ON [dbo].[Scrubbers] ([BlobId] ASC)

--- a/Sloth.Sql/dbo/Tables/Transactions.sql
+++ b/Sloth.Sql/dbo/Tables/Transactions.sql
@@ -21,7 +21,7 @@ CREATE TABLE [dbo].[Transactions] (
     CONSTRAINT [FK_Transactions_Sources_SourceId] FOREIGN KEY ([SourceId]) REFERENCES [dbo].[Sources] ([Id]) ON DELETE CASCADE,
     CONSTRAINT [FK_Transactions_Transactions_ReversalOfTransactionId] FOREIGN KEY ([ReversalOfTransactionId]) REFERENCES [dbo].[Transactions] ([Id]),
     CONSTRAINT [FK_Transactions_Transactions_ReversalTransactionId] FOREIGN KEY ([ReversalTransactionId]) REFERENCES [dbo].[Transactions] ([Id]), 
-    CONSTRAINT [FK_Transactions_CybersourceBankReconcileJobRecords_CybersourceBankReconcileJobRecordId] FOREIGN KEY ([CybersourceBankReconcileJobRecordId]) REFERENCES [CyberSourceBankReconcileJobRecords]([Id]),
+    CONSTRAINT [FK_Transactions_CybersourceBankReconcileJobRecords_CybersourceBankReconcileJobRecordId] FOREIGN KEY ([CybersourceBankReconcileJobRecordId]) REFERENCES [CybersourceBankReconcileJobRecords]([Id]),
     CONSTRAINT [FK_Transactions_KfsScrubberUploadJobRecords_KfsScrubberUploadJobRecordId] FOREIGN KEY ([KfsScrubberUploadJobRecordId]) REFERENCES [KfsScrubberUploadJobRecords]([Id])
 );
 

--- a/Sloth.Web/Controllers/JobsController.cs
+++ b/Sloth.Web/Controllers/JobsController.cs
@@ -166,7 +166,12 @@ namespace Sloth.Web.Controllers
                 // schedule methods
                 log.Information("Starting Job");
 
-                await _cyberSourceBankReconcileService.ProcessOneTimeIntegration(integration, reportName, date, record, log);
+                var jobBlob = await _cyberSourceBankReconcileService.ProcessOneTimeIntegration(integration, reportName, date, record, log);
+                if (jobBlob != null)
+                {
+                    // save uploaded blob metadata
+                    _dbContext.CybersourceBankReconcileJobBlobs.Add(jobBlob);
+                }
             }
             finally
             {
@@ -267,7 +272,12 @@ namespace Sloth.Web.Controllers
                 {
                     // call methods
                     log.Information("Starting Job");
-                    await cybersourceBankReconcileJob.ProcessReconcile(date, record, log);
+                    await foreach (var jobBlob in cybersourceBankReconcileJob.ProcessReconcile(date, record, log))
+                    {
+                        if (jobBlob == null) continue;
+                        // save uploaded blob metadata
+                        dbContext.CybersourceBankReconcileJobBlobs.Add(jobBlob);
+                    }
                 }
                 finally
                 {


### PR DESCRIPTION
closes  #138

Adds Blobs and CybersourceBankReconcileJobBlobs tables. The latter is necessary to accommodate multiple blobs, since reconcile reports are processed per integration.

Sloth.Jobs.CyberSource.BankReconcile is updated and will need to be deployed. I don't recall if anything needs to be done for that outside of the publish pipeline.