### PR TITLE
Fix authorizations

### DIFF
--- a/Sloth.Web/Controllers/IntegrationsController.cs
+++ b/Sloth.Web/Controllers/IntegrationsController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Sloth.Core;
@@ -9,9 +10,11 @@ using Sloth.Core.Resources;
 using Sloth.Core.Services;
 using Sloth.Web.Identity;
 using Sloth.Web.Models.IntegrationViewModels;
+using Sloth.Web.Resources;
 
 namespace Sloth.Web.Controllers
 {
+    [Authorize(Policy = PolicyCodes.TeamAdmin)]
     public class IntegrationsController : SuperController
     {
         private readonly ISecretsService _secretsService;

--- a/Sloth.Web/Controllers/ScrubbersController.cs
+++ b/Sloth.Web/Controllers/ScrubbersController.cs
@@ -12,7 +12,7 @@ using Sloth.Web.Resources;
 
 namespace Sloth.Web.Controllers
 {
-    [Authorize(Policy = PolicyCodes.TeamAdmin)]
+    [Authorize(Policy = PolicyCodes.TeamApprover)]
     public class ScrubbersController : SuperController
     {
         public ScrubbersController(ApplicationUserManager userManager, SlothDbContext dbContext) : base(userManager, dbContext)

--- a/Sloth.Web/Controllers/ScrubbersController.cs
+++ b/Sloth.Web/Controllers/ScrubbersController.cs
@@ -1,15 +1,18 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Sloth.Core;
 using Sloth.Web.Identity;
 using Sloth.Web.Models.ScrubberViewModels;
 using Sloth.Web.Models.TransactionViewModels;
+using Sloth.Web.Resources;
 
 namespace Sloth.Web.Controllers
 {
+    [Authorize(Policy = PolicyCodes.TeamAdmin)]
     public class ScrubbersController : SuperController
     {
         public ScrubbersController(ApplicationUserManager userManager, SlothDbContext dbContext) : base(userManager, dbContext)

--- a/Sloth.Web/Controllers/TeamsController.cs
+++ b/Sloth.Web/Controllers/TeamsController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Sloth.Core;
@@ -8,6 +9,7 @@ using Sloth.Core.Extensions;
 using Sloth.Core.Models;
 using Sloth.Web.Identity;
 using Sloth.Web.Models.TeamViewModels;
+using Sloth.Web.Resources;
 
 namespace Sloth.Web.Controllers
 {
@@ -23,6 +25,7 @@ namespace Sloth.Web.Controllers
             return View(teams);
         }
 
+        [Authorize(Policy = PolicyCodes.TeamAdmin)]
         public async Task<IActionResult> Details()
         {
             var team = await DbContext.Teams
@@ -50,12 +53,14 @@ namespace Sloth.Web.Controllers
             return View(team);
         }
 
+        [Authorize(Policy = PolicyCodes.TeamAdmin)]
         [HttpGet]
         public IActionResult Create()
         {
             return View();
         }
 
+        [Authorize(Policy = PolicyCodes.TeamAdmin)]
         [HttpPost]
         public async Task<IActionResult> Create(CreateTeamViewModel model)
         {
@@ -83,6 +88,7 @@ namespace Sloth.Web.Controllers
             return RedirectToAction("Details", new { id = team.Id });
         }
 
+        [Authorize(Policy = PolicyCodes.TeamAdmin)]
         [HttpGet]
         public async Task<IActionResult> Edit()
         {
@@ -107,6 +113,7 @@ namespace Sloth.Web.Controllers
             return View(model);
         }
 
+        [Authorize(Policy = PolicyCodes.TeamAdmin)]
         [HttpPost]
         public async Task<IActionResult> Edit(EditTeamViewModel model)
         {
@@ -129,6 +136,7 @@ namespace Sloth.Web.Controllers
             return RedirectToAction("Details", new { id = team.Id });
         }
 
+        [Authorize(Policy = PolicyCodes.TeamAdmin)]
         [HttpPost]
         public async Task<IActionResult> CreateUserRole(string teamId, string userId, string roleId)
         {
@@ -154,6 +162,7 @@ namespace Sloth.Web.Controllers
             });
         }
 
+        [Authorize(Policy = PolicyCodes.TeamAdmin)]
         [HttpPost]
         public async Task<IActionResult> CreateNewApiKey(string teamId)
         {
@@ -178,6 +187,7 @@ namespace Sloth.Web.Controllers
             });
         }
 
+        [Authorize(Policy = PolicyCodes.TeamAdmin)]
         [HttpPost]
         public async Task<IActionResult> RevokeApiKey(string id, string teamId)
         {

--- a/Sloth.Web/Controllers/TransactionsController.cs
+++ b/Sloth.Web/Controllers/TransactionsController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
@@ -12,9 +13,11 @@ using Sloth.Core.Resources;
 using Sloth.Core.Services;
 using Sloth.Web.Identity;
 using Sloth.Web.Models.TransactionViewModels;
+using Sloth.Web.Resources;
 
 namespace Sloth.Web.Controllers
 {
+    [Authorize(Policy = PolicyCodes.TeamAdmin)]
     public class TransactionsController : SuperController
     {
         private readonly IWebHookService WebHookService;

--- a/Sloth.Web/Controllers/TransactionsController.cs
+++ b/Sloth.Web/Controllers/TransactionsController.cs
@@ -17,7 +17,7 @@ using Sloth.Web.Resources;
 
 namespace Sloth.Web.Controllers
 {
-    [Authorize(Policy = PolicyCodes.TeamAdmin)]
+    [Authorize(Policy = PolicyCodes.TeamApprover)]
     public class TransactionsController : SuperController
     {
         private readonly IWebHookService WebHookService;

--- a/Sloth.Web/Controllers/UsersController.cs
+++ b/Sloth.Web/Controllers/UsersController.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Sloth.Core;
 using Sloth.Core.Models;
 using Sloth.Core.Services;
 using Sloth.Web.Identity;
+using Sloth.Web.Resources;
 
 namespace Sloth.Web.Controllers
 {
@@ -76,6 +78,7 @@ namespace Sloth.Web.Controllers
             });
         }
 
+        [Authorize(Policy = PolicyCodes.TeamAdmin)]
         [HttpPost]
         public async Task<IActionResult> CreateUserFromDirectory(string query)
         {

--- a/Sloth.Web/Controllers/WebHooksController.cs
+++ b/Sloth.Web/Controllers/WebHooksController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Sloth.Core;
@@ -8,9 +9,11 @@ using Sloth.Core.Models;
 using Sloth.Core.Services;
 using Sloth.Web.Identity;
 using Sloth.Web.Models.WebHookViewModels;
+using Sloth.Web.Resources;
 
 namespace Sloth.Web.Controllers
 {
+    [Authorize(Policy = PolicyCodes.TeamAdmin)]
     public class WebHooksController : SuperController
     {
         private readonly IWebHookService _webHookService;

--- a/Sloth.Web/Handlers/VerifyTeamPermissionHandler.cs
+++ b/Sloth.Web/Handlers/VerifyTeamPermissionHandler.cs
@@ -16,13 +16,11 @@ namespace Sloth.Web.Handlers
     {
         private readonly UserManager<User> _userManager;
         private readonly IHttpContextAccessor _httpContext;
-        private readonly ITempDataDictionaryFactory _tempDataDictionaryFactory;
 
-        public VerifyTeamPermissionHandler(UserManager<User> userManager, IHttpContextAccessor httpContext, ITempDataDictionaryFactory tempDataDictionary)
+        public VerifyTeamPermissionHandler(UserManager<User> userManager, IHttpContextAccessor httpContext)
         {
             _userManager = userManager;
             _httpContext = httpContext;
-            _tempDataDictionaryFactory = tempDataDictionary;
         }
 
         protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, VerifyTeamPermission requirement)
@@ -52,8 +50,6 @@ namespace Sloth.Web.Handlers
                     context.Succeed(requirement);
                 }
             }
-
-            // TODO: Check for system admin role
         }
     }
 }


### PR DESCRIPTION
- Fixes upgrade regression in VerifyTeamPermissionHandler.
- Adds missing Authorize attributes on controllers.

I wasn't sure on some of the controllers whether to authorize with a  TeamAdmin policy or a SystemAdmin role. I went with TeamAdmin for all of them, since controllers most likely needing SystemAdmin already have it. I couldn't place the Authorize attribute at controller level for the TeamsController since at least one action doesn't have a team slug passed in.