### PR TITLE
Add TransactionStatusEvents

### DIFF
--- a/Sloth.Api/Controllers/TransactionsController.cs
+++ b/Sloth.Api/Controllers/TransactionsController.cs
@@ -193,14 +193,9 @@ namespace Sloth.Api.Controllers
                 }).ToList(),
             };
 
-            if (transaction.AutoApprove)
-            {
-                transactionToCreate.Status = TransactionStatuses.Scheduled;
-            }
-            else
-            {
-                transactionToCreate.Status = TransactionStatuses.PendingApproval;
-            }
+            transactionToCreate.SetStatus(transaction.AutoApprove
+                ? TransactionStatuses.Scheduled
+                : TransactionStatuses.PendingApproval);
 
             using (var tran = _context.Database.BeginTransaction())
             {

--- a/Sloth.Core/Data/DbInitializer.cs
+++ b/Sloth.Core/Data/DbInitializer.cs
@@ -129,7 +129,6 @@ namespace Sloth.Core.Data
                 {
                     Creator                 = _context.Users.FirstOrDefault(u => u.UserName == "jpknoll"),
                     Source                  = _context.Sources.FirstOrDefault(s => s.Name == "ANLAB" && s.Type == "Recharge"),
-                    Status                  = TransactionStatuses.Scheduled,
                     MerchantTrackingNumber  = "ORDER-10",
                     ProcessorTrackingNumber = "123456",
                     KfsTrackingNumber       = "TESTTHIS1",
@@ -156,7 +155,7 @@ namespace Sloth.Core.Data
                             Direction   = Transfer.CreditDebit.Credit,
                         },
                     }
-                }
+                }.SetStatus(TransactionStatuses.Scheduled)
             };
             _context.Transactions.AddRange(transactions);
             _context.SaveChanges();

--- a/Sloth.Core/Domain/Transaction.cs
+++ b/Sloth.Core/Domain/Transaction.cs
@@ -153,30 +153,13 @@ namespace Sloth.Core.Models
         public Transaction SetStatus(string status, [CallerMemberName] string memberName = "",
             [CallerFilePath] string sourceFilePath = "", [CallerLineNumber] int sourceLineNumber = 0)
         {
-            var previousStatusEvent = StatusEvents
-                .Where(e => e.ValidToDate == null)
-                .OrderByDescending(e => e.ValidFromDate)
-                .FirstOrDefault();
-
-            var statusChangeDate = DateTime.UtcNow;
-
-            if (previousStatusEvent != null)
-                previousStatusEvent.ValidToDate = statusChangeDate;
-
-            var statusChange = "";
-
-            if (StatusEvents.Count > 0)
-                statusChange = Status == status ? "Status not changed" : "Status changed";
-            else
-                statusChange = "Status assigned";
-
             StatusEvents.Add(new TransactionStatusEvent
             {
                 TransactionId = Id,
                 Status = status,
-                ValidFromDate = statusChangeDate,
+                EventDate = DateTime.UtcNow,
                 EventDetails =
-                    $"File: {Path.GetFileName(sourceFilePath)}, Member: {memberName}, Line: {sourceLineNumber}, ({statusChange})"
+                    $"File: {Path.GetFileName(sourceFilePath)}, Member: {memberName}, Line: {sourceLineNumber}"
             });
 
             Status = status;

--- a/Sloth.Core/Domain/Transaction.cs
+++ b/Sloth.Core/Domain/Transaction.cs
@@ -16,6 +16,7 @@ namespace Sloth.Core.Models
         public Transaction()
         {
             Transfers = new List<Transfer>();
+            StatusEvents = new List<TransactionStatusEvent>();
         }
 
         public string Id { get; set; } = Guid.NewGuid().ToString();
@@ -152,7 +153,7 @@ namespace Sloth.Core.Models
         public Transaction SetStatus(string status, [CallerMemberName] string memberName = "",
             [CallerFilePath] string sourceFilePath = "", [CallerLineNumber] int sourceLineNumber = 0)
         {
-            var previousStatusEvent = StatusEvents?
+            var previousStatusEvent = StatusEvents
                 .Where(e => e.ValidToDate == null)
                 .OrderByDescending(e => e.ValidFromDate)
                 .FirstOrDefault();
@@ -161,8 +162,6 @@ namespace Sloth.Core.Models
 
             if (previousStatusEvent != null)
                 previousStatusEvent.ValidToDate = statusChangeDate;
-
-            StatusEvents ??= new List<TransactionStatusEvent>();
 
             var statusChange = "";
 

--- a/Sloth.Core/Domain/TransactionStatusEvent.cs
+++ b/Sloth.Core/Domain/TransactionStatusEvent.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Newtonsoft.Json;
+using System.ComponentModel;
+using Microsoft.EntityFrameworkCore;
+
+namespace Sloth.Core.Models
+{
+    public class TransactionStatusEvent
+    {
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+
+        public string Status { get; set; }
+
+        public DateTime ValidFromDate { get; set; }
+
+        public DateTime? ValidToDate { get; set; }
+
+        public string EventDetails { get; set; }
+
+        public string TransactionId { get; set; }
+
+        public Transaction Transaction { get; set; }
+
+    }
+}

--- a/Sloth.Core/Domain/TransactionStatusEvent.cs
+++ b/Sloth.Core/Domain/TransactionStatusEvent.cs
@@ -14,9 +14,7 @@ namespace Sloth.Core.Models
 
         public string Status { get; set; }
 
-        public DateTime ValidFromDate { get; set; }
-
-        public DateTime? ValidToDate { get; set; }
+        public DateTime EventDate { get; set; }
 
         public string EventDetails { get; set; }
 

--- a/Sloth.Core/Jobs/KfsScrubberUploadJob.cs
+++ b/Sloth.Core/Jobs/KfsScrubberUploadJob.cs
@@ -82,8 +82,8 @@ namespace Sloth.Core.Jobs
                         // update transactions' status and jobRecord
                         groupedTransactions.ForEach(t =>
                         {
-                            t.Status = TransactionStatuses.Completed;
                             t.KfsScrubberUploadJobRecordId = jobRecord.Id;
+                            t.SetStatus(TransactionStatuses.Completed);
                         });
 
                         // save per scrubber

--- a/Sloth.Core/Jobs/KfsScrubberUploadJob.cs
+++ b/Sloth.Core/Jobs/KfsScrubberUploadJob.cs
@@ -33,6 +33,7 @@ namespace Sloth.Core.Jobs
                     .Include(t => t.Source)
                         .ThenInclude(s => s.Team)
                     .Include(t => t.ReversalOfTransaction)
+                    .Include(t => t.StatusEvents)
                     .ToListAsync();
 
                 if (!transactions.Any())

--- a/Sloth.Core/Jobs/KfsScrubberUploadJob.cs
+++ b/Sloth.Core/Jobs/KfsScrubberUploadJob.cs
@@ -33,7 +33,6 @@ namespace Sloth.Core.Jobs
                     .Include(t => t.Source)
                         .ThenInclude(s => s.Team)
                     .Include(t => t.ReversalOfTransaction)
-                    .Include(t => t.StatusEvents)
                     .ToListAsync();
 
                 if (!transactions.Any())

--- a/Sloth.Core/Services/CyberSourceBankReconcileService.cs
+++ b/Sloth.Core/Services/CyberSourceBankReconcileService.cs
@@ -161,14 +161,13 @@ namespace Sloth.Core.Services
                         transaction = new Transaction()
                         {
                             Source                              = integration.Source,
-                            Status                              = TransactionStatuses.Scheduled,
                             DocumentNumber                      = documentNumber,
                             KfsTrackingNumber                   = kfsTrackingNumber,
                             MerchantTrackingNumber              = deposit.MerchantReferenceNumber,
                             ProcessorTrackingNumber             = deposit.RequestID,
                             TransactionDate                     = deposit.LocalizedRequestDate,
                             CybersourceBankReconcileJobRecordId = jobRecord.Id
-                        };
+                        }.SetStatus(TransactionStatuses.Scheduled);
 
                         // move money out of clearing
                         var clearing = new Transfer()

--- a/Sloth.Core/SlothDbContext.cs
+++ b/Sloth.Core/SlothDbContext.cs
@@ -46,6 +46,8 @@ namespace Sloth.Core
 
         public DbSet<CybersourceBankReconcileJobBlob> CybersourceBankReconcileJobBlobs { get; set; }
 
+        public DbSet<TransactionStatusEvent> TransactionStatusEvents { get; set; }
+
         public async Task<string> GetNextKfsTrackingNumber(DbTransaction transaction = null)
         {
             const string sql = "SELECT NEXT VALUE FOR KFS_Tracking_Number_Seq AS KfsTrackingNumber";

--- a/Sloth.Sql/Compare/SqlSchemaCompare_localhost.scmp
+++ b/Sloth.Sql/Compare/SqlSchemaCompare_localhost.scmp
@@ -157,6 +157,10 @@
         <Value>False</Value>
       </PropertyElementName>
       <PropertyElementName>
+        <Name>IgnoreTablePartitionOptions</Name>
+        <Value>False</Value>
+      </PropertyElementName>
+      <PropertyElementName>
         <Name>IgnoreWithNocheckOnCheckConstraints</Name>
         <Value>False</Value>
       </PropertyElementName>
@@ -437,6 +441,10 @@
         <Value>False</Value>
       </PropertyElementName>
       <PropertyElementName>
+        <Name>DoNotDropFiles</Name>
+        <Value>False</Value>
+      </PropertyElementName>
+      <PropertyElementName>
         <Name>DoNotDropFileTables</Name>
         <Value>False</Value>
       </PropertyElementName>
@@ -681,6 +689,10 @@
         <Value>False</Value>
       </PropertyElementName>
       <PropertyElementName>
+        <Name>ExcludeFiles</Name>
+        <Value>True</Value>
+      </PropertyElementName>
+      <PropertyElementName>
         <Name>ExcludeFileTables</Name>
         <Value>False</Value>
       </PropertyElementName>
@@ -911,180 +923,411 @@
     <ZoomLevel>100</ZoomLevel>
     <Filter>Equals_Objects,Not_Supported_Deploy</Filter>
   </SchemaCompareViewSettings>
+  <ExcludedSourceElements>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>ApiKeys</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>AspNetRoles</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>AspNetRoleClaims</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>AspNetUserClaims</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>AspNetUsers</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>CybersourceBankReconcileJobRecords</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>Integrations</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>KfsScrubberUploadJobRecords</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>Logs</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>Logs</Name>
+      <Name>IX_Logs_CorrelationId</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>Logs</Name>
+      <Name>IX_Logs_JobNameId</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>Logs</Name>
+      <Name>IX_Logs_Source</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>Scrubbers</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>Sources</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>Teams</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>Teams</Name>
+      <Name>IX_Teams_Name</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>Transactions</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>Transfers</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>WebHooks</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlDefaultConstraint, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name></Name>
+      <ParentItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+        <Name>dbo</Name>
+        <Name>WebHooks</Name>
+      </ParentItem>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlForeignKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>FK_WebHooks_Teams_TeamId</Name>
+    </SelectedItem>
+  </ExcludedSourceElements>
   <ExcludedTargetElements>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlSchema, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlSchema, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>State</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlPrimaryKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlPrimaryKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>PK_HangFire_State</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlForeignKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlForeignKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>FK_HangFire_State_Job</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>State</Name>
       <Name>IX_HangFire_State_JobId</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>Set</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlPrimaryKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlPrimaryKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>PK_HangFire_Set</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>Set</Name>
       <Name>UX_HangFire_Set_KeyAndValue</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>Set</Name>
       <Name>IX_HangFire_Set_ExpireAt</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>Set</Name>
       <Name>IX_HangFire_Set_Key</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>Server</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlPrimaryKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlPrimaryKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>PK_HangFire_Server</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>Schema</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlPrimaryKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlPrimaryKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>PK_HangFire_Schema</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>List</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlPrimaryKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlPrimaryKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>PK_HangFire_List</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>List</Name>
       <Name>IX_HangFire_List_ExpireAt</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>List</Name>
       <Name>IX_HangFire_List_Key</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>JobQueue</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlPrimaryKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlPrimaryKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>PK_HangFire_JobQueue</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>JobQueue</Name>
       <Name>IX_HangFire_JobQueue_QueueAndFetchedAt</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>JobParameter</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlPrimaryKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlPrimaryKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>PK_HangFire_JobParameter</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlForeignKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlForeignKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>FK_HangFire_JobParameter_Job</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>JobParameter</Name>
       <Name>IX_HangFire_JobParameter_JobIdAndName</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>Job</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlPrimaryKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlPrimaryKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>PK_HangFire_Job</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>Job</Name>
       <Name>IX_HangFire_Job_StateName</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>Job</Name>
       <Name>IX_HangFire_Job_ExpireAt</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>Hash</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlPrimaryKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlPrimaryKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>PK_HangFire_Hash</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>Hash</Name>
       <Name>UX_HangFire_Hash_Key_Field</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>Hash</Name>
       <Name>IX_HangFire_Hash_ExpireAt</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>Hash</Name>
       <Name>IX_HangFire_Hash_Key</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>Counter</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlPrimaryKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlPrimaryKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>PK_HangFire_Counter</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>Counter</Name>
       <Name>IX_HangFire_Counter_Key</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>AggregatedCounter</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlPrimaryKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlPrimaryKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>PK_HangFire_CounterAggregated</Name>
     </SelectedItem>
-    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Name>HangFire</Name>
       <Name>AggregatedCounter</Name>
       <Name>UX_HangFire_CounterAggregated_Key</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>Blobs</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlPrimaryKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>PK_Blobs</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>CybersourceBankReconcileJobBlobs</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlPrimaryKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>PK_CybersourceBankReconcileJobBlobs</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlForeignKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>FK_CybersourceBankReconcileJobBlobs_Blobs_BlobId</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlForeignKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>FK_CybersourceBankReconcileJobBlobs_CybersourceBankReconcileJobRecords_CybersourceBankReconcileJobRecordId</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlForeignKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>FK_CybersourceBankReconcileJobBlobs_Integrations_IntegrationId</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>CybersourceBankReconcileJobBlobs</Name>
+      <Name>IX_CybersourceBankReconcileJobBlobs_BlobId</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>CybersourceBankReconcileJobBlobs</Name>
+      <Name>IX_CybersourceBankReconcileJobBlobs_CybersourceBankReconcileJobRecordId</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>CybersourceBankReconcileJobBlobs</Name>
+      <Name>IX_CybersourceBankReconcileJobBlobs_IntegrationId</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>ApiKeys</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>AspNetRoles</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>AspNetRoleClaims</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>AspNetUserClaims</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>AspNetUsers</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>CybersourceBankReconcileJobRecords</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>Integrations</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>KfsScrubberUploadJobRecords</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlForeignKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>FK_KfsScrubberUploadJobRecords_Blobs_BlobId</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>KfsScrubberUploadJobRecords</Name>
+      <Name>IX_KfsScrubberUploadJobRecords_BlobId</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>Logs</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlForeignKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>FK_Logs_CybersourceBankReconcileJobRecords_JobId</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlForeignKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>FK_Logs_KfsScrubberUploadJobRecords_JobId</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>Scrubbers</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlForeignKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>FK_Scrubbers_Blobs_BlobId</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>Scrubbers</Name>
+      <Name>IX_Scrubbers_BlobId</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>Sources</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>Teams</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlIndex, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>Teams</Name>
+      <Name>IX_Teams_Name</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>Transactions</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>Transfers</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlTable, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>WebHooks</Name>
+    </SelectedItem>
+    <SelectedItem Type="Microsoft.Data.Tools.Schema.Sql.SchemaModel.SqlForeignKeyConstraint, Microsoft.Data.Tools.Schema.Sql, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Name>dbo</Name>
+      <Name>FK_WebHooks_Teams_TeamId</Name>
     </SelectedItem>
   </ExcludedTargetElements>
 </SchemaComparison>

--- a/Sloth.Sql/Sloth.Sql.sqlproj
+++ b/Sloth.Sql/Sloth.Sql.sqlproj
@@ -92,6 +92,7 @@
     <Build Include="dbo\Tables\KfsScrubberUploadJobRecords.sql" />
     <Build Include="dbo\Sequences\Document_Number_Seq.sql" />
     <Build Include="dbo\Tables\WebHooks.sql" />
+    <Build Include="dbo\Tables\TransactionStatusEvents.sql" />
     <Build Include="dbo\Tables\Blobs.sql" />
     <Build Include="dbo\Tables\CybersourceBankReconcileJobBlobs.sql" />
   </ItemGroup>

--- a/Sloth.Sql/dbo/Tables/TransactionStatusEvents.sql
+++ b/Sloth.Sql/dbo/Tables/TransactionStatusEvents.sql
@@ -3,8 +3,7 @@ CREATE TABLE [dbo].[TransactionStatusEvents]
     [Id] NVARCHAR(450) NOT NULL PRIMARY KEY, 
     [TransactionId] NVARCHAR(450) NOT NULL,
     [Status] NVARCHAR(50) NOT NULL, 
-    [ValidFromDate] DATETIME2 NOT NULL, 
-    [ValidToDate] DATETIME2 NULL, 
+    [EventDate] DATETIME2 NOT NULL, 
     [EventDetails] NVARCHAR(450) NOT NULL, 
     CONSTRAINT [FK_TransactionStatusEvents_Transactions] FOREIGN KEY ([TransactionId]) REFERENCES [Transactions]([Id])
 )
@@ -19,11 +18,7 @@ CREATE NONCLUSTERED INDEX [IX_TransactionStatusEvents_Status] ON [dbo].[Transact
 
 GO
 
-CREATE NONCLUSTERED INDEX [IX_TransactionStatusEvents_ValidFromDate] ON [dbo].[TransactionStatusEvents] ([ValidFromDate] ASC)
-
-GO
-
-CREATE NONCLUSTERED INDEX [IX_TransactionStatusEvents_ValidToDate] ON [dbo].[TransactionStatusEvents] ([ValidToDate] ASC)
+CREATE NONCLUSTERED INDEX [IX_TransactionStatusEvents_EventDate] ON [dbo].[TransactionStatusEvents] ([EventDate] ASC)
 
 GO
 

--- a/Sloth.Sql/dbo/Tables/TransactionStatusEvents.sql
+++ b/Sloth.Sql/dbo/Tables/TransactionStatusEvents.sql
@@ -21,5 +21,3 @@ GO
 CREATE NONCLUSTERED INDEX [IX_TransactionStatusEvents_EventDate] ON [dbo].[TransactionStatusEvents] ([EventDate] ASC)
 
 GO
-
-CREATE NONCLUSTERED INDEX [IX_TransactionStatusEvents_EventDetails] ON [dbo].[TransactionStatusEvents] ([EventDetails] ASC)

--- a/Sloth.Sql/dbo/Tables/TransactionStatusEvents.sql
+++ b/Sloth.Sql/dbo/Tables/TransactionStatusEvents.sql
@@ -1,0 +1,30 @@
+CREATE TABLE [dbo].[TransactionStatusEvents]
+(
+    [Id] NVARCHAR(450) NOT NULL PRIMARY KEY, 
+    [TransactionId] NVARCHAR(450) NOT NULL,
+    [Status] NVARCHAR(50) NOT NULL, 
+    [ValidFromDate] DATETIME2 NOT NULL, 
+    [ValidToDate] DATETIME2 NULL, 
+    [EventDetails] NVARCHAR(450) NOT NULL, 
+    CONSTRAINT [FK_TransactionStatusEvents_Transactions] FOREIGN KEY ([TransactionId]) REFERENCES [Transactions]([Id])
+)
+
+GO
+
+CREATE NONCLUSTERED INDEX [IX_TransactionStatusEvents_TransactionId] ON [dbo].[TransactionStatusEvents] ([TransactionId] ASC)
+
+GO
+
+CREATE NONCLUSTERED INDEX [IX_TransactionStatusEvents_Status] ON [dbo].[TransactionStatusEvents] ([Status] ASC)
+
+GO
+
+CREATE NONCLUSTERED INDEX [IX_TransactionStatusEvents_ValidFromDate] ON [dbo].[TransactionStatusEvents] ([ValidFromDate] ASC)
+
+GO
+
+CREATE NONCLUSTERED INDEX [IX_TransactionStatusEvents_ValidToDate] ON [dbo].[TransactionStatusEvents] ([ValidToDate] ASC)
+
+GO
+
+CREATE NONCLUSTERED INDEX [IX_TransactionStatusEvents_EventDetails] ON [dbo].[TransactionStatusEvents] ([EventDetails] ASC)

--- a/Sloth.Web/Controllers/TransactionsController.cs
+++ b/Sloth.Web/Controllers/TransactionsController.cs
@@ -121,7 +121,7 @@ namespace Sloth.Web.Controllers
                 .ToListAsync();
 
             // update status
-            transactions.ForEach(t => t.Status = TransactionStatuses.Scheduled);
+            transactions.ForEach(t => t.SetStatus(TransactionStatuses.Scheduled));
 
             // save to db
             await DbContext.SaveChangesAsync();
@@ -162,7 +162,7 @@ namespace Sloth.Web.Controllers
                 return NotFound();
             }
 
-            transaction.Status = TransactionStatuses.Scheduled;
+            transaction.SetStatus(TransactionStatuses.Scheduled);
 
             await DbContext.SaveChangesAsync();
 
@@ -203,12 +203,11 @@ namespace Sloth.Web.Controllers
                 Source                  = transaction.Source,
                 Creator                 = user,
                 TransactionDate         = DateTime.UtcNow,
-                Status                  = TransactionStatuses.Scheduled,
                 KfsTrackingNumber       = transaction.KfsTrackingNumber,
                 MerchantTrackingNumber  = transaction.MerchantTrackingNumber,
                 MerchantTrackingUrl     = transaction.MerchantTrackingUrl,
                 ProcessorTrackingNumber = transaction.ProcessorTrackingNumber,
-            };
+            }.SetStatus(TransactionStatuses.Scheduled);
 
             // add reversal transfers
             foreach (var transfer in transaction.Transfers)

--- a/Sloth.Web/Controllers/TransactionsController.cs
+++ b/Sloth.Web/Controllers/TransactionsController.cs
@@ -116,6 +116,7 @@ namespace Sloth.Web.Controllers
             // fetch transactions
             var transactions = await DbContext.Transactions
                 .Include(t => t.Transfers)
+                .Include(t => t.StatusEvents)
                 .Where(t => t.Source.Team.Slug == TeamSlug)
                 .Where(t => t.Status == TransactionStatuses.PendingApproval)
                 .ToListAsync();
@@ -149,6 +150,7 @@ namespace Sloth.Web.Controllers
             var transaction = await DbContext.Transactions
                 .Include(t => t.Scrubber)
                 .Include(t => t.Transfers)
+                .Include(t => t.StatusEvents)
                 .FirstOrDefaultAsync(t => t.Id == id);
 
             //TODO: return error messages and redirect

--- a/Sloth.Web/Controllers/TransactionsController.cs
+++ b/Sloth.Web/Controllers/TransactionsController.cs
@@ -116,7 +116,6 @@ namespace Sloth.Web.Controllers
             // fetch transactions
             var transactions = await DbContext.Transactions
                 .Include(t => t.Transfers)
-                .Include(t => t.StatusEvents)
                 .Where(t => t.Source.Team.Slug == TeamSlug)
                 .Where(t => t.Status == TransactionStatuses.PendingApproval)
                 .ToListAsync();
@@ -150,7 +149,6 @@ namespace Sloth.Web.Controllers
             var transaction = await DbContext.Transactions
                 .Include(t => t.Scrubber)
                 .Include(t => t.Transfers)
-                .Include(t => t.StatusEvents)
                 .FirstOrDefaultAsync(t => t.Id == id);
 
             //TODO: return error messages and redirect


### PR DESCRIPTION
Setter for `Transaction.Status` is now private to force usage of `Transaction.SetStatus()` which creates a new `TransactionStatusEvent` with details about when and where in code Status was set. (I ❤️ `[CallerMemberName]` and friends) 

closes #144