### PR TITLE
fix regexes

### DIFF
--- a/Sloth.Core/Extensions/AggieEnterpriseExtensions.cs
+++ b/Sloth.Core/Extensions/AggieEnterpriseExtensions.cs
@@ -7,7 +7,7 @@ namespace Sloth.Core.Extensions
         public static string StripToErpName(this string value, int maxLength = Int32.MaxValue)
         {
             // Erp names can only contain letters, numbers, hyphen, spaces and underscores.
-            const string regexStr = @"[^0-9a-zA-Z\ \_\-\']+";
+            const string regexStr = @"[^0-9a-zA-Z\ \-_]+";
 
             return value.SafeRegexRemove(regexStr).SafeTruncate(maxLength);
         }
@@ -15,7 +15,7 @@ namespace Sloth.Core.Extensions
         public static string StripToErpDescription(this string value, int maxLength = Int32.MaxValue)
         {
             //  limited to letters, numbers, hyphen, underscore, spaces, and periods.
-            const string regexStr = @"[^0-9a-zA-Z\ \.\-\_']+";
+            const string regexStr = @"[^0-9a-zA-Z\ \.\-_]+";
 
             return value.SafeRegexRemove(regexStr).SafeTruncate(maxLength);
         }
@@ -23,7 +23,7 @@ namespace Sloth.Core.Extensions
         public static string StripToGlReferenceField(this string value, int maxLength = Int32.MaxValue)
         {
             //  limited to letters, numbers, hyphen, and underscore
-            const string regexStr = @"[^0-9a-zA-Z\-\_']+";
+            const string regexStr = @"[^0-9a-zA-Z\-_]+";
 
             return value.SafeRegexRemove(regexStr).SafeTruncate(maxLength);
         }


### PR DESCRIPTION
`_` doesn't need to be escaped, and the trailing `'` wasn't needed either