### PR TITLE
table to track job runs

### DIFF
--- a/Sloth.Core/Domain/CybersourceBankReconcileJobRecord.cs
+++ b/Sloth.Core/Domain/CybersourceBankReconcileJobRecord.cs
@@ -7,7 +7,7 @@ using Sloth.Core.Domain;
 
 namespace Sloth.Core.Models
 {
-    public class CybersourceBankReconcileJobRecord : JobRecord
+    public class CybersourceBankReconcileJobRecord : JobRecordBase
     {
         [Display(Name = "Processed Date")]
         public DateTime ProcessedDate { get; set; }

--- a/Sloth.Core/Domain/JobRecord.cs
+++ b/Sloth.Core/Domain/JobRecord.cs
@@ -1,0 +1,44 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using Newtonsoft.Json;
+
+namespace Sloth.Core.Models
+{
+    public class JobRecord
+    {
+        public JobRecord()
+        {
+            StartedAt = DateTime.UtcNow;
+        }
+
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+
+        [Required]
+        [StringLength(256)]
+        public string Name { get; set; }
+
+        public DateTime StartedAt { get; set; }
+
+        public DateTime? EndedAt { get; set; }
+
+        [StringLength(32)]
+        public string Status { get; set; }
+
+        public string Details { get; set; }
+
+        public void SetDetails(object details)
+        {
+            // convert to json string and store
+            Details = JsonConvert.SerializeObject(details);
+        }
+
+        // list of possible statuses
+        public static class Statuses
+        {
+            public const string Pending = "Pending";
+            public const string Running = "Running";
+            public const string Success = "Success";
+            public const string Failed = "Failed";
+        }
+    }
+}

--- a/Sloth.Core/Domain/JobRecord.cs
+++ b/Sloth.Core/Domain/JobRecord.cs
@@ -32,6 +32,13 @@ namespace Sloth.Core.Models
             Details = JsonConvert.SerializeObject(details);
         }
 
+        public void SetCompleted(string status, object details)
+        {
+            EndedAt = DateTime.UtcNow;
+            Status = status;
+            SetDetails(details);
+        }
+
         // list of possible statuses
         public static class Statuses
         {

--- a/Sloth.Core/Domain/JobRecord.cs
+++ b/Sloth.Core/Domain/JobRecord.cs
@@ -1,6 +1,6 @@
 using System;
 using System.ComponentModel.DataAnnotations;
-using Newtonsoft.Json;
+using System.Text.Json;
 
 namespace Sloth.Core.Models
 {
@@ -29,7 +29,7 @@ namespace Sloth.Core.Models
         public void SetDetails(object details)
         {
             // convert to json string and store
-            Details = JsonConvert.SerializeObject(details);
+            Details = JsonSerializer.Serialize(details);
         }
 
         public void SetCompleted(string status, object details)

--- a/Sloth.Core/Domain/JobRecordBase.cs
+++ b/Sloth.Core/Domain/JobRecordBase.cs
@@ -4,7 +4,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Sloth.Core.Models
 {
-    public abstract class JobRecord
+    public abstract class JobRecordBase
     {
         public string Id { get; set; } = Guid.NewGuid().ToString();
 

--- a/Sloth.Core/Domain/KfsScrubberUploadJobRecord.cs
+++ b/Sloth.Core/Domain/KfsScrubberUploadJobRecord.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Sloth.Core.Models
 {
-    public class KfsScrubberUploadJobRecord : JobRecord
+    public class KfsScrubberUploadJobRecord : JobRecordBase
     {
         public IList<Transaction> Transactions { get; set; }
 

--- a/Sloth.Core/Domain/WebHookRequestResendJobRecord.cs
+++ b/Sloth.Core/Domain/WebHookRequestResendJobRecord.cs
@@ -7,7 +7,7 @@ using Sloth.Core.Domain;
 
 namespace Sloth.Core.Models
 {
-    public class WebHookRequestResendJobRecord : JobRecord
+    public class WebHookRequestResendJobRecord : JobRecordBase
     {
         public IList<WebHookRequest> WebHookRequests { get; set; }
 

--- a/Sloth.Core/Jobs/AggieEnterpriseJournalJob.cs
+++ b/Sloth.Core/Jobs/AggieEnterpriseJournalJob.cs
@@ -121,7 +121,6 @@ namespace Sloth.Core.Jobs
                                 journalRequest.Status = requestStatus.RequestStatus.ToString();
 
                                 transactionRunStatus.Action = requestStatus.RequestStatus.ToString();
-                                ;
                             }
 
                             // TODO: These are likely the only two statuses possible for a new request, but confirm

--- a/Sloth.Core/Migrations/20220801180410_JobRecords.Designer.cs
+++ b/Sloth.Core/Migrations/20220801180410_JobRecords.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Sloth.Core;
 
@@ -11,9 +12,10 @@ using Sloth.Core;
 namespace Sloth.Core.Migrations
 {
     [DbContext(typeof(SlothDbContext))]
-    partial class SlothDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220801180410_JobRecords")]
+    partial class JobRecords
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Sloth.Core/Migrations/20220801180410_JobRecords.cs
+++ b/Sloth.Core/Migrations/20220801180410_JobRecords.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Sloth.Core.Migrations
+{
+    public partial class JobRecords : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "JobRecords",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: false),
+                    StartedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    EndedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    Status = table.Column<string>(type: "nvarchar(32)", maxLength: 32, nullable: true),
+                    Details = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_JobRecords", x => x.Id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "JobRecords");
+        }
+    }
+}

--- a/Sloth.Core/SlothDbContext.cs
+++ b/Sloth.Core/SlothDbContext.cs
@@ -26,6 +26,8 @@ namespace Sloth.Core
 
         public DbSet<Source> Sources { get; set; }
 
+        public DbSet<JobRecord> JobRecords { get; set; }
+
         public DbSet<JournalRequest> JournalRequests { get; set; }
 
         public DbSet<Transaction> Transactions { get; set; }

--- a/Sloth.Web/Views/Jobs/_LogConsole.cshtml
+++ b/Sloth.Web/Views/Jobs/_LogConsole.cshtml
@@ -1,5 +1,5 @@
 @using Newtonsoft.Json
-@model Sloth.Core.Models.JobRecord
+@model Sloth.Core.Models.JobRecordBase
 
 <link href="~/css/prism.css" rel="stylesheet" />
 <style>


### PR DESCRIPTION
Basic table which contains info about job runs, both in progress and once completed.  Stores a json object with run details for later inspection.

closes #233 but we should eventually make some UX for viewing recent job runs