### PR TITLE
Add metadata to transactions

### DIFF
--- a/Sloth.Api/Controllers/v2/TransactionsController.cs
+++ b/Sloth.Api/Controllers/v2/TransactionsController.cs
@@ -276,7 +276,7 @@ namespace Sloth.Api.Controllers.v2
                 : TransactionStatuses.PendingApproval);
 
             // assign metadata if it exists
-            if (transaction.Metadata.Count > 0)
+            if (transaction.Metadata is { Count: > 0 })
             {
                 foreach (var entry in transaction.Metadata)
                 {

--- a/Sloth.Api/Models/v2/CreateTransactionViewModel.cs
+++ b/Sloth.Api/Models/v2/CreateTransactionViewModel.cs
@@ -63,6 +63,11 @@ namespace Sloth.Api.Models.v2
         [Required]
         public string SourceType { get; set; }
 
+        /// <summary>
+        /// Optional key/value pairs of generic metadata that will persist with this transaction
+        /// </summary>
+        public Dictionary<string, string> Metadata { get; set; }
+
         public string Description { get; set; }
 
         [ListMinLength(2)]

--- a/Sloth.Core/Domain/Transaction.cs
+++ b/Sloth.Core/Domain/Transaction.cs
@@ -17,6 +17,7 @@ namespace Sloth.Core.Models
         {
             Transfers = new List<Transfer>();
             StatusEvents = new List<TransactionStatusEvent>();
+            Metadata = new List<TransactionMetadata>();
         }
 
         public string Id { get; set; } = Guid.NewGuid().ToString();

--- a/Sloth.Core/Domain/Transaction.cs
+++ b/Sloth.Core/Domain/Transaction.cs
@@ -141,6 +141,8 @@ namespace Sloth.Core.Models
 
         public IList<TransactionBlob> TransactionBlobs { get; set; }
 
+        public IList<TransactionMetadata> Metadata { get; set; }
+
         public void AddReversalTransaction(Transaction transaction)
         {
             // setup bidirectional relationship
@@ -188,6 +190,12 @@ namespace Sloth.Core.Models
 
             modelBuilder.Entity<Transaction>()
                 .HasMany(t => t.TransactionBlobs)
+                .WithOne(b => b.Transaction)
+                .HasForeignKey(r => r.TransactionId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            modelBuilder.Entity<Transaction>()
+                .HasMany(t => t.Metadata)
                 .WithOne(b => b.Transaction)
                 .HasForeignKey(r => r.TransactionId)
                 .OnDelete(DeleteBehavior.Restrict);

--- a/Sloth.Core/Domain/TransactionMetadata.cs
+++ b/Sloth.Core/Domain/TransactionMetadata.cs
@@ -1,0 +1,23 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+
+namespace Sloth.Core.Models
+{
+    public class TransactionMetadata
+    {
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+
+        public string TransactionId { get; set; }
+
+        public Transaction Transaction { get; set; }
+
+        public string Name { get; set; }
+
+        public string Value { get; set; }
+
+        public static void OnModelCreating(ModelBuilder modelBuilder)
+        {
+
+        }
+    }
+}

--- a/Sloth.Core/Domain/TransactionMetadata.cs
+++ b/Sloth.Core/Domain/TransactionMetadata.cs
@@ -1,5 +1,6 @@
 using System;
 using Microsoft.EntityFrameworkCore;
+using System.ComponentModel.DataAnnotations;
 
 namespace Sloth.Core.Models
 {
@@ -11,8 +12,11 @@ namespace Sloth.Core.Models
 
         public Transaction Transaction { get; set; }
 
+        [Required]
+        [MaxLength(128)]
         public string Name { get; set; }
 
+        [Required]
         public string Value { get; set; }
 
         public static void OnModelCreating(ModelBuilder modelBuilder)

--- a/Sloth.Core/Domain/TransactionMetadata.cs
+++ b/Sloth.Core/Domain/TransactionMetadata.cs
@@ -17,7 +17,11 @@ namespace Sloth.Core.Models
 
         public static void OnModelCreating(ModelBuilder modelBuilder)
         {
+            modelBuilder.Entity<TransactionMetadata>()
+                .HasIndex(r => r.TransactionId);
 
+            // modelBuilder.Entity<TransactionMetadata>()
+            //     .HasIndex(r => r.Name);
         }
     }
 }

--- a/Sloth.Core/Migrations/20221206175414_TransactionMetadata.Designer.cs
+++ b/Sloth.Core/Migrations/20221206175414_TransactionMetadata.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Sloth.Core;
 
@@ -11,9 +12,10 @@ using Sloth.Core;
 namespace Sloth.Core.Migrations
 {
     [DbContext(typeof(SlothDbContext))]
-    partial class SlothDbContextModelSnapshot : ModelSnapshot
+    [Migration("20221206175414_TransactionMetadata")]
+    partial class TransactionMetadata
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -659,15 +661,12 @@ namespace Sloth.Core.Migrations
                         .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("Name")
-                        .IsRequired()
-                        .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("TransactionId")
                         .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("Value")
-                        .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
                     b.HasKey("Id");

--- a/Sloth.Core/Migrations/20221206175414_TransactionMetadata.cs
+++ b/Sloth.Core/Migrations/20221206175414_TransactionMetadata.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Sloth.Core.Migrations
+{
+    public partial class TransactionMetadata : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "TransactionMetadata",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    TransactionId = table.Column<string>(type: "nvarchar(450)", nullable: true),
+                    Name = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Value = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TransactionMetadata", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_TransactionMetadata_Transactions_TransactionId",
+                        column: x => x.TransactionId,
+                        principalTable: "Transactions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TransactionMetadata_TransactionId",
+                table: "TransactionMetadata",
+                column: "TransactionId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "TransactionMetadata");
+        }
+    }
+}

--- a/Sloth.Core/Migrations/20221206175956_TransactionMetadataConstraints.Designer.cs
+++ b/Sloth.Core/Migrations/20221206175956_TransactionMetadataConstraints.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Sloth.Core;
 
@@ -11,9 +12,10 @@ using Sloth.Core;
 namespace Sloth.Core.Migrations
 {
     [DbContext(typeof(SlothDbContext))]
-    partial class SlothDbContextModelSnapshot : ModelSnapshot
+    [Migration("20221206175956_TransactionMetadataConstraints")]
+    partial class TransactionMetadataConstraints
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Sloth.Core/Migrations/20221206175956_TransactionMetadataConstraints.cs
+++ b/Sloth.Core/Migrations/20221206175956_TransactionMetadataConstraints.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Sloth.Core.Migrations
+{
+    public partial class TransactionMetadataConstraints : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Value",
+                table: "TransactionMetadata",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "TransactionMetadata",
+                type: "nvarchar(128)",
+                maxLength: 128,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Value",
+                table: "TransactionMetadata",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "TransactionMetadata",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(128)",
+                oldMaxLength: 128);
+        }
+    }
+}

--- a/Sloth.Web/Controllers/TransactionsController.cs
+++ b/Sloth.Web/Controllers/TransactionsController.cs
@@ -157,6 +157,7 @@ namespace Sloth.Web.Controllers
                 .Include(t => t.ReversalTransaction)
                 .Include(t => t.ReversalOfTransaction)
                 .Include(t => t.StatusEvents)
+                .Include(t => t.Metadata)
                 .AsNoTracking()
                 .FirstOrDefaultAsync(t => t.Id == id);
 

--- a/Sloth.Web/Views/Shared/_MetadataTableScript.cshtml
+++ b/Sloth.Web/Views/Shared/_MetadataTableScript.cshtml
@@ -1,0 +1,11 @@
+<script>
+  $('#metadataTable').dataTable({
+    language: {
+      searchPlaceholder: "Filter Metadata",
+      search: "",
+    },
+   "paging": false,
+    "info": false,
+  });
+
+</script>

--- a/Sloth.Web/Views/Transactions/Details.cshtml
+++ b/Sloth.Web/Views/Transactions/Details.cshtml
@@ -26,7 +26,6 @@ else
     <partial name="_AeDetails" model="Model" />
 @* } *@
 
-
 <div class="row mt-5">
     <h2>Activity Timeline</h2>
     @foreach (var activity in Model.Transaction.StatusEvents.OrderBy(a => a.EventDate))
@@ -41,6 +40,14 @@ else
         </div>
     }
 </div>
+
+@if (Model.Transaction.Metadata.Any())
+{
+    <div class="row mt-5">
+    <h2>Metadata</h2>
+    <partial name="_TransactionMetadata" model="Model.Transaction.Metadata" />
+    </div>
+}
 
 @if (Model.RelatedTransactions.Transactions.Any())
 {
@@ -63,7 +70,7 @@ else
 
  @section AdditionalScripts {
     <script src="~/js/prism.js"></script>
-<script>
+    <script>
         $('#transfers').DataTable({
             "columnDefs": [
                 { "targets": 0, "visible": false }
@@ -75,10 +82,17 @@ else
             searching: false,
         });
     </script>
+
+    @if (Model.Transaction.Metadata.Any())
+    {
+        <partial name="_MetadataTableScript" />
+    }
+
     @if (Model.RelatedTransactions.Transactions.Any())
     {
         <partial name="_TransactionsTableScript" />
     }
+
     @if (Model.RelatedBlobs.Blobs.Any())
     {
         <partial name="_BlobsTableScript" />

--- a/Sloth.Web/Views/Transactions/_TransactionMetadata.cshtml
+++ b/Sloth.Web/Views/Transactions/_TransactionMetadata.cshtml
@@ -1,0 +1,19 @@
+@model IList<TransactionMetadata>
+
+<table id="metadataTable" class="table sloth-table">
+    <thead>
+        <tr>
+            <th>Key</th>
+            <th>Value</th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach (var t in Model)
+        {
+            <tr>
+                <td>@t.Name</td>
+                <td>@t.Value</td>
+            </tr>
+        }
+    </tbody>
+</table>


### PR DESCRIPTION
When creating a txn through the API, you can now optionally send in key/value metadata.  When you use the API to pull back txns, you'll get the metadata returned.  Also the metadata is shown on the txn details page.