### PR TITLE
store ConsumerTrackingId in db column during AE upload

### DIFF
--- a/Sloth.Core/Domain/Transaction.cs
+++ b/Sloth.Core/Domain/Transaction.cs
@@ -100,6 +100,13 @@ namespace Sloth.Core.Models
         public string KfsTrackingNumber { get; set; }
 
         /// <summary>
+        /// Unique identifier for tracking this transaction through the financial system (Aggie Enterprise)
+        /// </summary>
+        [MaxLength(128)]
+        [DisplayName("Consumer Tracking Id")]
+        public string ConsumerTrackingId { get; set; }
+
+        /// <summary>
         /// Date the transaction occurred.
         /// </summary>
         [Required]

--- a/Sloth.Core/Jobs/AggieEnterpriseJournalJob.cs
+++ b/Sloth.Core/Jobs/AggieEnterpriseJournalJob.cs
@@ -96,6 +96,9 @@ namespace Sloth.Core.Jobs
 
                         try
                         {
+                            // create a new trackingId for the AE Service to use
+                            transaction.ConsumerTrackingId = Guid.NewGuid().ToString();
+
                             var result = await _aggieEnterpriseService.CreateJournal(source, transaction);
                             var requestStatus = result.GlJournalRequest.RequestStatus;
 

--- a/Sloth.Core/Migrations/20230214223942_ConsumerTrackingId.Designer.cs
+++ b/Sloth.Core/Migrations/20230214223942_ConsumerTrackingId.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Sloth.Core;
 
@@ -11,9 +12,10 @@ using Sloth.Core;
 namespace Sloth.Core.Migrations
 {
     [DbContext(typeof(SlothDbContext))]
-    partial class SlothDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230214223942_ConsumerTrackingId")]
+    partial class ConsumerTrackingId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Sloth.Core/Migrations/20230214223942_ConsumerTrackingId.cs
+++ b/Sloth.Core/Migrations/20230214223942_ConsumerTrackingId.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Sloth.Core.Migrations
+{
+    public partial class ConsumerTrackingId : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ConsumerTrackingId",
+                table: "Transactions",
+                type: "nvarchar(128)",
+                maxLength: 128,
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ConsumerTrackingId",
+                table: "Transactions");
+        }
+    }
+}

--- a/Sloth.Core/Services/AggieEnterpriseService.cs
+++ b/Sloth.Core/Services/AggieEnterpriseService.cs
@@ -123,7 +123,7 @@ namespace Sloth.Core.Services
             {
                 Header = new ActionRequestHeaderInput
                 {
-                    ConsumerTrackingId = transaction.Id.SafeTruncate(80),
+                    ConsumerTrackingId = transaction.ConsumerTrackingId.SafeTruncate(80),
                     ConsumerReferenceId = source.Name.SafeTruncate(80),
                     ConsumerNotes =
                         transaction.Description.SafeTruncate(240),
@@ -156,12 +156,12 @@ namespace Sloth.Core.Services
         /// <param name="requestId">Found in JournalRequest.RequestId</param>
         /// <returns></returns>
         public async Task<IGlJournalRequestStatusResult> GetJournalStatus(Guid requestId)
-        {           
+        {
             var result = await _aggieClient.GlJournalRequestStatus.ExecuteAsync(requestId);
 
             return result.ReadData();
         }
-        
+
         private PpmSegmentInput ConvertToPpmSegmentInput(PpmSegments segments)
         {
             return new PpmSegmentInput


### PR DESCRIPTION
Id is regenerated on every upload (should just be once, but can be >1 if txn is rejected first time).   Note if there are existing pending txns they will not be able to be located unless we update the db to set this new field to equal the old Id (`update Transactions set ConsumerTrackingId = Id`) as a one-time update.