### PR TITLE
Allow manual txns via CreateExecutionStrategy

### DIFF
--- a/Sloth.Api/Controllers/v1/TransactionsController.cs
+++ b/Sloth.Api/Controllers/v1/TransactionsController.cs
@@ -213,7 +213,7 @@ namespace Sloth.Api.Controllers.v1
                 ? TransactionStatuses.Scheduled
                 : TransactionStatuses.PendingApproval);
 
-            using (var tran = _context.Database.BeginTransaction())
+            await ResilientTransaction.ExecuteAsync(_context, async tran =>
             {
                 // create document number
                 transactionToCreate.DocumentNumber = await _context.GetNextDocumentNumber(tran.GetDbTransaction());
@@ -226,10 +226,9 @@ namespace Sloth.Api.Controllers.v1
 
                 _context.Transactions.Add(transactionToCreate);
                 await _context.SaveChangesAsync();
-                tran.Commit();
+            });
 
-                return new JsonResult(transactionToCreate);
-            }
+            return new JsonResult(transactionToCreate);
         }
     }
 }

--- a/Sloth.Core/ResilientTransaction.cs
+++ b/Sloth.Core/ResilientTransaction.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Sloth.Core
+{
+    // Use of an EF Core resiliency strategy when using multiple DbContext calls
+    // within an explicit BeginTransaction():
+    // https://learn.microsoft.com/ef/core/miscellaneous/connection-resiliency
+    public static class ResilientTransaction
+    {
+        public static async Task ExecuteAsync(DbContext dbContext, Func<IDbContextTransaction, Task> action)
+        {
+            var strategy = dbContext.Database.CreateExecutionStrategy();
+            await strategy.ExecuteAsync(async () =>
+            {
+                await using var transaction = await dbContext.Database.BeginTransactionAsync();
+                await action(transaction);
+                await transaction.CommitAsync();
+            });
+        }
+
+        public static async Task<T> ExecuteAsync<T>(DbContext dbContext, Func<IDbContextTransaction, Task<T>> action)
+        {
+            var strategy = dbContext.Database.CreateExecutionStrategy();
+            T result = default;
+            await strategy.ExecuteAsync(async () =>
+            {
+                await using var transaction = await dbContext.Database.BeginTransactionAsync();
+                result = await action(transaction);
+                await transaction.CommitAsync();
+            });
+            return result;
+        }
+    }
+}

--- a/Sloth.Core/Services/CyberSourceBankReconcileService.cs
+++ b/Sloth.Core/Services/CyberSourceBankReconcileService.cs
@@ -138,7 +138,7 @@ namespace Sloth.Core.Services
         {
             var transactions = new List<Transaction>();
 
-            await using (var tran = await _context.Database.BeginTransactionAsync())
+            await ResilientTransaction.ExecuteAsync(_context, async tran =>
             {
                 try
                 {
@@ -279,7 +279,7 @@ namespace Sloth.Core.Services
                     log.Error(ex, ex.Message);
                     await tran.RollbackAsync();
                 }
-            }
+            });
 
             TransactionBlob transactionBlob = null;
             CybersourceBankReconcileIntegrationDetails details = new();

--- a/Sloth.Web/Controllers/TransactionsController.cs
+++ b/Sloth.Web/Controllers/TransactionsController.cs
@@ -223,9 +223,11 @@ namespace Sloth.Web.Controllers
                 return RedirectToAction(nameof(Index));
             }
 
-            if (transaction.Status != TransactionStatuses.Rejected && !transaction.IsStale())
+            if (transaction.Status != TransactionStatuses.PendingApproval
+                && transaction.Status != TransactionStatuses.Rejected
+                && !transaction.IsStale())
             {
-                ErrorMessage = "Transaction is not Stale (Processing for more than 5 days) or Rejected";
+                ErrorMessage = "Transaction is not Stale (Processing for more than 5 days), Rejected or PendingApproval";
                 return RedirectToAction(nameof(Details), new { id });
             }
 

--- a/Sloth.Web/Controllers/TransactionsController.cs
+++ b/Sloth.Web/Controllers/TransactionsController.cs
@@ -481,92 +481,94 @@ namespace Sloth.Web.Controllers
 
             var percentage = reversalAmount / totalAmount;
 
-            await using var tran = await DbContext.Database.BeginTransactionAsync();
-            var user = await UserManager.GetUserAsync(User);
+            Transaction reversal = null;
 
-            var documentNumber = await DbContext.GetNextDocumentNumber(tran.GetDbTransaction());
-
-            // create new transaction
-            var reversal = new Transaction
+            await ResilientTransaction.ExecuteAsync(DbContext, async tran =>
             {
-                Source = transaction.Source,
-                Creator = user,
-                TransactionDate = DateTime.UtcNow,
-                DocumentNumber = documentNumber,
-                KfsTrackingNumber = transaction.KfsTrackingNumber,
-                MerchantTrackingNumber = transaction.MerchantTrackingNumber,
-                MerchantTrackingUrl = transaction.MerchantTrackingUrl,
-                ProcessorTrackingNumber = transaction.ProcessorTrackingNumber,
-                Description = reversalAmount != totalAmount ? "Partial Reversal" : "Full Reversal",
-            }.SetStatus(TransactionStatuses.Scheduled);
+                var user = await UserManager.GetUserAsync(User);
 
-            // add reversal transfers
-            foreach (var transfer in transaction.Transfers)
-            {
-                var amount = Math.Round(transfer.Amount * percentage, 2);
-                // don't create a transfer if it rounds to less than one cent
-                if (amount < 0.01m)
+                var documentNumber = await DbContext.GetNextDocumentNumber(tran.GetDbTransaction());
+
+                // create new transaction
+                reversal = new Transaction
                 {
-                    continue;
+                    Source = transaction.Source,
+                    Creator = user,
+                    TransactionDate = DateTime.UtcNow,
+                    DocumentNumber = documentNumber,
+                    KfsTrackingNumber = transaction.KfsTrackingNumber,
+                    MerchantTrackingNumber = transaction.MerchantTrackingNumber,
+                    MerchantTrackingUrl = transaction.MerchantTrackingUrl,
+                    ProcessorTrackingNumber = transaction.ProcessorTrackingNumber,
+                    Description = reversalAmount != totalAmount ? "Partial Reversal" : "Full Reversal",
+                }.SetStatus(TransactionStatuses.Scheduled);
+
+                // add reversal transfers
+                foreach (var transfer in transaction.Transfers)
+                {
+                    var amount = Math.Round(transfer.Amount * percentage, 2);
+                    // don't create a transfer if it rounds to less than one cent
+                    if (amount < 0.01m)
+                    {
+                        continue;
+                    }
+
+                    // same info, except reverse direction
+                    var direction = transfer.Direction == Transfer.CreditDebit.Credit
+                        ? Transfer.CreditDebit.Debit
+                        : Transfer.CreditDebit.Credit;
+
+                    reversal.Transfers.Add(new Transfer
+                    {
+                        Amount = amount,
+                        Account = transfer.Account,
+                        Chart = transfer.Chart,
+                        Description = transfer.Description,
+                        Direction = direction,
+                        FiscalPeriod = DateTime.UtcNow.GetFiscalPeriod(),
+                        FiscalYear = DateTime.UtcNow.GetFinancialYear(),
+                        ObjectCode = transfer.ObjectCode,
+                        ObjectType = transfer.ObjectType,
+                        Project = transfer.Project,
+                        ReferenceId = transfer.ReferenceId,
+                        SequenceNumber = transfer.SequenceNumber,
+                        FinancialSegmentString = transfer.FinancialSegmentString,
+                        SubAccount = transfer.SubAccount,
+                        SubObjectCode = transfer.SubObjectCode,
+                    });
                 }
 
-                // same info, except reverse direction
-                var direction = transfer.Direction == Transfer.CreditDebit.Credit
-                    ? Transfer.CreditDebit.Debit
-                    : Transfer.CreditDebit.Credit;
+                var reversalCredits = reversal.Transfers.Where(t => t.Direction == Transfer.CreditDebit.Credit).ToArray();
+                var reversalDebits = reversal.Transfers.Where(t => t.Direction == Transfer.CreditDebit.Debit).ToArray();
+                var totalReversalCredit = reversalCredits.Sum(t => t.Amount);
+                var totalReversalDebit = reversalDebits.Sum(t => t.Amount);
 
-                reversal.Transfers.Add(new Transfer
+                /// adjust for rounding error
+                if (totalReversalDebit > totalReversalCredit)
                 {
-                    Amount = amount,
-                    Account = transfer.Account,
-                    Chart = transfer.Chart,
-                    Description = transfer.Description,
-                    Direction = direction,
-                    FiscalPeriod = DateTime.UtcNow.GetFiscalPeriod(),
-                    FiscalYear = DateTime.UtcNow.GetFinancialYear(),
-                    ObjectCode = transfer.ObjectCode,
-                    ObjectType = transfer.ObjectType,
-                    Project = transfer.Project,
-                    ReferenceId = transfer.ReferenceId,
-                    SequenceNumber = transfer.SequenceNumber,
-                    FinancialSegmentString = transfer.FinancialSegmentString,
-                    SubAccount = transfer.SubAccount,
-                    SubObjectCode = transfer.SubObjectCode,
-                });
-            }
-
-            var reversalCredits = reversal.Transfers.Where(t => t.Direction == Transfer.CreditDebit.Credit).ToArray();
-            var reversalDebits = reversal.Transfers.Where(t => t.Direction == Transfer.CreditDebit.Debit).ToArray();
-            var totalReversalCredit = reversalCredits.Sum(t => t.Amount);
-            var totalReversalDebit = reversalDebits.Sum(t => t.Amount);
-
-            /// adjust for rounding error
-            if (totalReversalDebit > totalReversalCredit)
-            {
-                var centIncrements = (int)Math.Round((totalReversalDebit - totalReversalCredit) * 100);
-                for (var i = 0; i < centIncrements; i++)
-                {
-                    reversalCredits[i % reversalCredits.Length].Amount += 0.01m;
+                    var centIncrements = (int)Math.Round((totalReversalDebit - totalReversalCredit) * 100);
+                    for (var i = 0; i < centIncrements; i++)
+                    {
+                        reversalCredits[i % reversalCredits.Length].Amount += 0.01m;
+                    }
                 }
-            }
-            else if (totalReversalCredit > totalReversalDebit)
-            {
-                var centIncrements = (int)Math.Round((totalReversalCredit - totalReversalDebit) * 100);
-                for (var i = 0; i < centIncrements; i++)
+                else if (totalReversalCredit > totalReversalDebit)
                 {
-                    reversalDebits[i % reversalDebits.Length].Amount += 0.01m;
+                    var centIncrements = (int)Math.Round((totalReversalCredit - totalReversalDebit) * 100);
+                    for (var i = 0; i < centIncrements; i++)
+                    {
+                        reversalDebits[i % reversalDebits.Length].Amount += 0.01m;
+                    }
                 }
-            }
 
-            // save transaction to establish id
-            await DbContext.Transactions.AddAsync(reversal);
-            await DbContext.SaveChangesAsync();
+                // save transaction to establish id
+                await DbContext.Transactions.AddAsync(reversal);
+                await DbContext.SaveChangesAsync();
 
-            // save relationship
-            transaction.AddReversalTransaction(reversal);
-            await DbContext.SaveChangesAsync();
-
-            await tran.CommitAsync();
+                // save relationship
+                transaction.AddReversalTransaction(reversal);
+                await DbContext.SaveChangesAsync();
+            });
 
             Message = "Reversal created successfully";
             return RedirectToAction("Details", new { id = reversal.Id });


### PR DESCRIPTION
Wasn't sure about having `ResilientTransaction.ExecuteAsync` be in charge of committing the transaction, but that was how it was done in the [MS example](https://learn.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/implement-resilient-entity-framework-core-sql-connections).

~Haven't actually tested. Just wanted to get it out there before focusing on something else.~

Closes #348 