### PR TITLE
Remove clutter from webhook log context

### DIFF
--- a/Sloth.Web/Controllers/WebHooksController.cs
+++ b/Sloth.Web/Controllers/WebHooksController.cs
@@ -131,6 +131,7 @@ namespace Sloth.Web.Controllers
         {
             var webhook = await DbContext.WebHooks
                 .Where(i => i.Team.Slug == TeamSlug)
+                .Include(i => i.Team)
                 .FirstOrDefaultAsync(i => i.Id == id);
             if (webhook == null)
             {

--- a/Sloth.Web/Program.cs
+++ b/Sloth.Web/Program.cs
@@ -24,6 +24,9 @@ namespace Sloth.Web
     {
         public static async Task Main(string[] args)
         {
+#if DEBUG
+            Serilog.Debugging.SelfLog.Enable(msg => System.Diagnostics.Debug.WriteLine(msg));
+#endif
             var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
             var isDevelopment = string.Equals(environment, "development", StringComparison.OrdinalIgnoreCase);
 


### PR DESCRIPTION
Didn't do a lot of testing, but enough to verify that Serilog is happy to use anonymous types as context objects