### PR TITLE
Pass the team name to the glide info

### DIFF
--- a/Sloth.Core/Services/AggieEnterpriseService.cs
+++ b/Sloth.Core/Services/AggieEnterpriseService.cs
@@ -92,7 +92,7 @@ namespace Sloth.Core.Services
                     LineDescription = transfer.Description.SafeTruncate(100), //Line Desc is max 100 chars, our desc is currently max 40 chars
                     TransactionDate = transaction.TransactionDate.Date.ToString("yyyy-MM-dd"),
                     UdfString1      = transaction.Description.SafeTruncate(50),
-                    UdfString2      = transaction.KfsTrackingNumber.StripToErpName(50),
+                    UdfString2      = transaction.Source?.Team?.Name.SafeTruncate(50), //None of this should be null, but just in case
                     UdfString3      = transaction.ProcessorTrackingNumber.SafeTruncate(50),
                     UdfString4      = transaction.MerchantTrackingNumber.SafeTruncate(50),
                     UdfString5      = transfer.Id.SafeTruncate(50)


### PR DESCRIPTION
instead of the kfs tracking number as this is already in the glide report column External System Identifier