### PR TITLE
Remove team permission check

### DIFF
--- a/Sloth.Web/Controllers/UsersController.cs
+++ b/Sloth.Web/Controllers/UsersController.cs
@@ -83,7 +83,6 @@ namespace Sloth.Web.Controllers
             });
         }
 
-        [Authorize(Policy = PolicyCodes.TeamAdmin)]
         [HttpPost]
         public async Task<IActionResult> CreateUserFromDirectory(string query)
         {


### PR DESCRIPTION
Close #400 

Don't really need or want this here.
It can be called (for system) without a team value.