### PR TITLE
allow empty ids in get methods that return arrays

### DIFF
--- a/Sloth.Api/Controllers/v2/TransactionsController.cs
+++ b/Sloth.Api/Controllers/v2/TransactionsController.cs
@@ -106,7 +106,7 @@ namespace Sloth.Api.Controllers.v2
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>
-        [HttpGet("processortrackingnumber/{id}")]
+        [HttpGet("processortrackingnumber/{id?}")]
         [ProducesResponseType(typeof(Transaction), 200)]
         public async Task<IList<Transaction>> GetAllByProcessorId(string id)
         {
@@ -134,7 +134,7 @@ namespace Sloth.Api.Controllers.v2
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>
-        [HttpGet("kfskey/{id}")]
+        [HttpGet("kfskey/{id?}")]
         [ProducesResponseType(typeof(IList<Transaction>), 200)]
         public async Task<IList<Transaction>> GetByKfsKey(string id)
         {


### PR DESCRIPTION
Still required if you are just getting one txn, since null is the best response for missing in that case.
