### PR TITLE
Report for stuck txns older than 1 day

### DIFF
--- a/Sloth.Web/Models/ReportViewModels/TransactionsReportViewModel.cs
+++ b/Sloth.Web/Models/ReportViewModels/TransactionsReportViewModel.cs
@@ -6,5 +6,7 @@ namespace Sloth.Web.Models.ReportViewModels
     public class TransactionsReportViewModel
     {
         public TransactionsTableViewModel TransactionsTable { get; set; }
+
+        public string? Information { get; set; }
     }
 }

--- a/Sloth.Web/Views/Reports/FailedTransactions.cshtml
+++ b/Sloth.Web/Views/Reports/FailedTransactions.cshtml
@@ -19,6 +19,12 @@
 
 <div class="container">
   <h2>@ViewBag.Title</h2>
+    @if (Model.Information != null)
+    {
+        <div class="alert alert-info" role="alert">
+            @Model.Information
+        </div>
+    }
   <div>
     <h4>Transactions</h4>
     <hr />

--- a/Sloth.Web/Views/Reports/Index.cshtml
+++ b/Sloth.Web/Views/Reports/Index.cshtml
@@ -65,6 +65,18 @@
                         </div>
                     </a>
                 </div>
+                <div class="card job">
+                    <a asp-action="FailedTransactionsAllTeams" asp-route-pendingOlderThanADay="true">
+                        <div class="card-body">
+                            <h5 class="card-title">
+                                Stuck Transactions Across All Teams
+                            </h5>
+                            <p class="card-text">
+                                Shows transactions across all teams that have been in status <code>Processing</code> for more than 1 day.
+                            </p>
+                        </div>
+                    </a>
+                </div>
             </div>
         }
     </div>


### PR DESCRIPTION
Many times, when we first get notified about stuck txns, then are other that are also stuck, but not at the 5 day threshold yet. We want to get these for AE also.