### PR TITLE
Enhance home page with admin team overview

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,7 +42,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +56,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -69,6 +69,6 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"

--- a/Sloth.Web/Controllers/HomeController.cs
+++ b/Sloth.Web/Controllers/HomeController.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
@@ -8,6 +10,7 @@ using Sloth.Core;
 using Sloth.Core.Resources;
 using Sloth.Web.Identity;
 using Sloth.Web.Models;
+using Sloth.Web.Models.HomeViewModels;
 using Sloth.Web.Resources;
 
 namespace Sloth.Web.Controllers
@@ -29,7 +32,53 @@ namespace Sloth.Web.Controllers
                 return RedirectToAction(nameof(TransactionsController.Index), "Transactions", new { team = team.Slug });
             }
 
-            return View(teams);
+            var model = new HomeIndexViewModel();
+            if (User.IsInRole(Roles.SystemAdmin))
+            {
+                var stuckCutoff = DateTime.UtcNow.Date.AddDays(-1);
+                var failedProcessingCutoff = DateTime.UtcNow.Date.AddDays(-5);
+
+                var teamsWithSources = await DbContext.Teams
+                    .Include(t => t.Sources)
+                    .AsNoTracking()
+                    .OrderBy(t => t.Name)
+                    .ToListAsync();
+
+                var failedTransactionCounts = await DbContext.Transactions
+                    .Where(t => t.Status == TransactionStatuses.Rejected
+                        || (t.Status == TransactionStatuses.Processing && t.LastModified < failedProcessingCutoff))
+                    .GroupBy(t => t.Source.Team.Slug)
+                    .Select(t => new
+                    {
+                        Slug = t.Key,
+                        Count = t.Count(),
+                    })
+                    .ToDictionaryAsync(t => t.Slug, t => t.Count);
+
+                var stuckTransactionCounts = await DbContext.Transactions
+                    .Where(t => (t.Status == TransactionStatuses.Processing && t.LastModified < stuckCutoff)
+                        || (t.Status == TransactionStatuses.Scheduled && t.LastModified < stuckCutoff))
+                    .GroupBy(t => t.Source.Team.Slug)
+                    .Select(t => new
+                    {
+                        Slug = t.Key,
+                        Count = t.Count(),
+                    })
+                    .ToDictionaryAsync(t => t.Slug, t => t.Count);
+
+                model.Teams = teamsWithSources
+                    .Select(t => new HomeTeamSummaryViewModel
+                    {
+                        Name = t.Name,
+                        Slug = t.Slug,
+                        SourceNames = t.Sources?.OrderBy(s => s.Name).Select(s => s.Name).ToList() ?? new List<string>(),
+                        FailedTransactionCount = failedTransactionCounts.TryGetValue(t.Slug, out var failedCount) ? failedCount : 0,
+                        StuckTransactionCount = stuckTransactionCounts.TryGetValue(t.Slug, out var stuckCount) ? stuckCount : 0,
+                    })
+                    .ToList();
+            }
+
+            return View(model);
         }
 
         [Authorize(Policy = PolicyCodes.TeamAnyRole)]

--- a/Sloth.Web/Controllers/HomeController.cs
+++ b/Sloth.Web/Controllers/HomeController.cs
@@ -32,41 +32,45 @@ namespace Sloth.Web.Controllers
                 return RedirectToAction(nameof(TransactionsController.Index), "Transactions", new { team = team.Slug });
             }
 
-            var model = new HomeIndexViewModel();
-            if (User.IsInRole(Roles.SystemAdmin))
+            var teamIds = teams.Select(t => t.Id).ToList();
+            var teamSlugs = teams.Select(t => t.Slug).ToList();
+            var stuckCutoff = DateTime.UtcNow.Date.AddDays(-1);
+            var failedProcessingCutoff = DateTime.UtcNow.Date.AddDays(-5);
+
+            var teamsWithSources = await DbContext.Teams
+                .Include(t => t.Sources)
+                .Where(t => teamIds.Contains(t.Id))
+                .AsNoTracking()
+                .OrderBy(t => t.Name)
+                .ToListAsync();
+
+            var failedTransactionCounts = await DbContext.Transactions
+                .Where(t => teamSlugs.Contains(t.Source.Team.Slug)
+                    && (t.Status == TransactionStatuses.Rejected
+                        || (t.Status == TransactionStatuses.Processing && t.LastModified < failedProcessingCutoff)))
+                .GroupBy(t => t.Source.Team.Slug)
+                .Select(t => new
+                {
+                    Slug = t.Key,
+                    Count = t.Count(),
+                })
+                .ToDictionaryAsync(t => t.Slug, t => t.Count);
+
+            var stuckTransactionCounts = await DbContext.Transactions
+                .Where(t => teamSlugs.Contains(t.Source.Team.Slug)
+                    && ((t.Status == TransactionStatuses.Processing && t.LastModified < stuckCutoff)
+                        || (t.Status == TransactionStatuses.Scheduled && t.LastModified < stuckCutoff)))
+                .GroupBy(t => t.Source.Team.Slug)
+                .Select(t => new
+                {
+                    Slug = t.Key,
+                    Count = t.Count(),
+                })
+                .ToDictionaryAsync(t => t.Slug, t => t.Count);
+
+            var model = new HomeIndexViewModel
             {
-                var stuckCutoff = DateTime.UtcNow.Date.AddDays(-1);
-                var failedProcessingCutoff = DateTime.UtcNow.Date.AddDays(-5);
-
-                var teamsWithSources = await DbContext.Teams
-                    .Include(t => t.Sources)
-                    .AsNoTracking()
-                    .OrderBy(t => t.Name)
-                    .ToListAsync();
-
-                var failedTransactionCounts = await DbContext.Transactions
-                    .Where(t => t.Status == TransactionStatuses.Rejected
-                        || (t.Status == TransactionStatuses.Processing && t.LastModified < failedProcessingCutoff))
-                    .GroupBy(t => t.Source.Team.Slug)
-                    .Select(t => new
-                    {
-                        Slug = t.Key,
-                        Count = t.Count(),
-                    })
-                    .ToDictionaryAsync(t => t.Slug, t => t.Count);
-
-                var stuckTransactionCounts = await DbContext.Transactions
-                    .Where(t => (t.Status == TransactionStatuses.Processing && t.LastModified < stuckCutoff)
-                        || (t.Status == TransactionStatuses.Scheduled && t.LastModified < stuckCutoff))
-                    .GroupBy(t => t.Source.Team.Slug)
-                    .Select(t => new
-                    {
-                        Slug = t.Key,
-                        Count = t.Count(),
-                    })
-                    .ToDictionaryAsync(t => t.Slug, t => t.Count);
-
-                model.Teams = teamsWithSources
+                Teams = teamsWithSources
                     .Select(t => new HomeTeamSummaryViewModel
                     {
                         Name = t.Name,
@@ -75,8 +79,8 @@ namespace Sloth.Web.Controllers
                         FailedTransactionCount = failedTransactionCounts.TryGetValue(t.Slug, out var failedCount) ? failedCount : 0,
                         StuckTransactionCount = stuckTransactionCounts.TryGetValue(t.Slug, out var stuckCount) ? stuckCount : 0,
                     })
-                    .ToList();
-            }
+                    .ToList(),
+            };
 
             return View(model);
         }

--- a/Sloth.Web/Controllers/HomeController.cs
+++ b/Sloth.Web/Controllers/HomeController.cs
@@ -35,7 +35,6 @@ namespace Sloth.Web.Controllers
             var teamIds = teams.Select(t => t.Id).ToList();
             var teamSlugs = teams.Select(t => t.Slug).ToList();
             var stuckCutoff = DateTime.UtcNow.Date.AddDays(-1);
-            var failedProcessingCutoff = DateTime.UtcNow.Date.AddDays(-5);
 
             var teamsWithSources = await DbContext.Teams
                 .Include(t => t.Sources)
@@ -46,8 +45,7 @@ namespace Sloth.Web.Controllers
 
             var failedTransactionCounts = await DbContext.Transactions
                 .Where(t => teamSlugs.Contains(t.Source.Team.Slug)
-                    && (t.Status == TransactionStatuses.Rejected
-                        || (t.Status == TransactionStatuses.Processing && t.LastModified < failedProcessingCutoff)))
+                    && t.Status == TransactionStatuses.Rejected)
                 .GroupBy(t => t.Source.Team.Slug)
                 .Select(t => new
                 {

--- a/Sloth.Web/Models/HomeViewModels/HomeIndexViewModel.cs
+++ b/Sloth.Web/Models/HomeViewModels/HomeIndexViewModel.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace Sloth.Web.Models.HomeViewModels
+{
+    public class HomeIndexViewModel
+    {
+        public IReadOnlyList<HomeTeamSummaryViewModel> Teams { get; set; } = new List<HomeTeamSummaryViewModel>();
+    }
+
+    public class HomeTeamSummaryViewModel
+    {
+        public string Name { get; set; }
+
+        public string Slug { get; set; }
+
+        public IReadOnlyList<string> SourceNames { get; set; } = new List<string>();
+
+        public int FailedTransactionCount { get; set; }
+
+        public int StuckTransactionCount { get; set; }
+    }
+}

--- a/Sloth.Web/Views/Home/Index.cshtml
+++ b/Sloth.Web/Views/Home/Index.cshtml
@@ -4,21 +4,14 @@
     ViewData["Title"] = "Home Page";
 }
 
-<div class="container">
-    <div class="row">
-        <div class="col">
-            <h1>SLOTH</h1>
-            <ul>
-                <li>Secure <span style="text-decoration: line-through">Scrubber</span></li>
-                <li>Ledger <span style="text-decoration: line-through">Loader</span></li>
-                <li>Online</li>
-                <li>Transaction</li>
-                <li>Hub</li>
-            </ul>
-            </div>
-            </div>
-                        
-        <h2>@(User.IsInRole(Roles.SystemAdmin) ? "All Teams:" : "Your Teams:")</h2>
+<div class="container home-page">
+    <div class="home-heading">
+        <h1>S.L.O.T.H.</h1>
+        <p>Secure Ledger Online Transaction Hub</p>
+    </div>
+
+    <div class="home-teams">
+        <h2>@(User.IsInRole(Roles.SystemAdmin) ? "All Teams" : "Your Teams")</h2>
 
         <div class="responsive-table">
             <table id="homeTeamsTable" class="table sloth-table active-table">
@@ -48,6 +41,7 @@
                 </tbody>
             </table>
         </div>
+    </div>
 </div>
 
 @section AdditionalScripts {

--- a/Sloth.Web/Views/Home/Index.cshtml
+++ b/Sloth.Web/Views/Home/Index.cshtml
@@ -1,5 +1,5 @@
 @using Sloth.Core.Resources
-@model IEnumerable<Sloth.Core.Models.Team>
+@model Sloth.Web.Models.HomeViewModels.HomeIndexViewModel
 @{
     ViewData["Title"] = "Home Page";
 }
@@ -23,15 +23,54 @@
 
         <h2>All Teams:</h2>
 
-        <div class="row flex-column align-items-start justify-content-center">
-            @foreach (var team in Model)
-            {
-                <div class="col-sm-12 col-md-5">
-                    <a asp-controller="Home" asp-action="TeamIndex" asp-route-team="@team.Slug">
-                        <span>@team.Name</span>
-                    </a>
-                </div>
-            }
+        <div class="responsive-table">
+            <table id="homeTeamsTable" class="table sloth-table active-table">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Slug</th>
+                        <th>Sources</th>
+                        <th>Failed Transactions</th>
+                        <th>Stuck Transactions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var team in Model.Teams)
+                    {
+                        var teamUrl = Url.Action("TeamIndex", "Home", new { team = team.Slug });
+                        <tr data-href="@teamUrl">
+                            <td>
+                                <a href="@teamUrl">@team.Name</a>
+                            </td>
+                            <td>@team.Slug</td>
+                            <td>@(team.SourceNames.Any() ? string.Join(", ", team.SourceNames) : "None")</td>
+                            <td>@team.FailedTransactionCount</td>
+                            <td>@team.StuckTransactionCount</td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
         </div>
     }
 </div>
+
+@section AdditionalScripts {
+    @if (User.IsInRole(Roles.SystemAdmin))
+    {
+        <script>
+            $('#homeTeamsTable').DataTable({
+                order: [[0, 'asc']],
+                pageLength: -1,
+                lengthMenu: [[10, 25, 50, -1], [10, 25, 50, 'All']],
+                language: {
+                    searchPlaceholder: "Search Table",
+                    search: "",
+                },
+            });
+
+            $('#homeTeamsTable tbody').on('click', 'tr', function () {
+                window.location = $(this).data('href');
+            });
+        </script>
+    }
+}

--- a/Sloth.Web/Views/Home/Index.cshtml
+++ b/Sloth.Web/Views/Home/Index.cshtml
@@ -18,10 +18,7 @@
             </div>
             </div>
                         
-    @if (User.IsInRole(Roles.SystemAdmin))
-    {
-
-        <h2>All Teams:</h2>
+        <h2>@(User.IsInRole(Roles.SystemAdmin) ? "All Teams:" : "Your Teams:")</h2>
 
         <div class="responsive-table">
             <table id="homeTeamsTable" class="table sloth-table active-table">
@@ -51,26 +48,22 @@
                 </tbody>
             </table>
         </div>
-    }
 </div>
 
 @section AdditionalScripts {
-    @if (User.IsInRole(Roles.SystemAdmin))
-    {
-        <script>
-            $('#homeTeamsTable').DataTable({
-                order: [[0, 'asc']],
-                pageLength: -1,
-                lengthMenu: [[10, 25, 50, -1], [10, 25, 50, 'All']],
-                language: {
-                    searchPlaceholder: "Search Table",
-                    search: "",
-                },
-            });
+    <script>
+        $('#homeTeamsTable').DataTable({
+            order: [[0, 'asc']],
+            pageLength: -1,
+            lengthMenu: [[10, 25, 50, -1], [10, 25, 50, 'All']],
+            language: {
+                searchPlaceholder: "Search Table",
+                search: "",
+            },
+        });
 
-            $('#homeTeamsTable tbody').on('click', 'tr', function () {
-                window.location = $(this).data('href');
-            });
-        </script>
-    }
+        $('#homeTeamsTable tbody').on('click', 'tr', function () {
+            window.location = $(this).data('href');
+        });
+    </script>
 }

--- a/Sloth.Web/Views/Home/Index.cshtml
+++ b/Sloth.Web/Views/Home/Index.cshtml
@@ -20,7 +20,7 @@
                         <th>Name</th>
                         <th>Slug</th>
                         <th>Sources</th>
-                        <th>Failed Transactions</th>
+                        <th>Rejected Transactions</th>
                         <th>Stuck Transactions</th>
                     </tr>
                 </thead>

--- a/Sloth.Web/wwwroot/scss/layout.scss
+++ b/Sloth.Web/wwwroot/scss/layout.scss
@@ -98,6 +98,55 @@ footer {
 .body-content {
   padding-top: 2rem;
 }
+.home-page {
+  .home-heading {
+    width: 100%;
+    max-width: 960px;
+    margin: 0;
+    padding: 2.5rem 0 1.25rem;
+
+    h1 {
+      margin-bottom: 0.1rem;
+      font-size: 2rem;
+      line-height: 1.1;
+    }
+
+    p {
+      margin-bottom: 0;
+      color: $secondary-font;
+      font-size: 0.95rem;
+      text-transform: uppercase;
+    }
+  }
+
+  .home-teams {
+    margin-top: 3.5rem;
+
+    h2 {
+      display: inline-block;
+      margin: 0 0 1rem;
+      padding-bottom: 0.45rem;
+      border-bottom: 3px solid $primary-color;
+      color: $primary-color;
+      font-size: 1.5rem;
+      line-height: 1.2;
+    }
+  }
+
+  .responsive-table {
+    border: 1px solid $borders-sloth;
+    background-color: #fff;
+  }
+
+  table.sloth-table {
+    margin-bottom: 0;
+    border: 0;
+
+    thead th {
+      background-color: $bg-primary;
+    }
+  }
+}
 .filters-wrapper {
   margin-bottom: 3%;
   .status-filter {


### PR DESCRIPTION
Provide System Administrators with a table overview of all teams, including associated sources and counts for failed and stuck transactions.


<img width="2636" height="1751" alt="image" src="https://github.com/user-attachments/assets/16e550dc-0a0c-4fb4-837b-36c875ae002a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Home page now displays teams in a sortable, filterable table format.
  * Added per-team counters for failed and stuck transactions.
  * Team source names are now visible in the table.

* **Style**
  * Enhanced home page layout with improved visual organization and structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->