### PR TITLE
Correctly add new API key row to DataTable

### DIFF
--- a/Sloth.Web/Views/Teams/Details.cshtml
+++ b/Sloth.Web/Views/Teams/Details.cshtml
@@ -481,15 +481,13 @@
                         .text('Revoke Key');
 
                     // create new row in table
+                    var $row = $('<tr></tr>');
+                    $row.append($('<td nowrap></td>').text(result.key));
+                    $row.append($('<td></td>').attr('data-sort', result.issuedTicks).text(result.issued));
+                    $row.append($('<td></td>').append($button));
+
                     var apiKeysTable = $('#apiKeysTable').DataTable();
-                    apiKeysTable.row.add([
-                        result.key,
-                        {
-                            "display": result.issued,
-                            "@@data-sort": result.issuedTicks,
-                        },
-                        $('<div>').append($button).html(),
-                    ]).draw();
+                    apiKeysTable.row.add($row[0]).draw();
 
                     $('#create-key-modal').modal('hide');
                 });


### PR DESCRIPTION
Issue #373

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the API key management table in Teams details. Newly created API key rows now render correctly with proper formatting. The "Issued" column now supports sorting, making it easier to organize and locate specific API keys by creation date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->