### PR TITLE
Add reversal transaction links to details views

### DIFF
--- a/Sloth.Web/Views/Transactions/_AeDetails.cshtml
+++ b/Sloth.Web/Views/Transactions/_AeDetails.cshtml
@@ -104,6 +104,38 @@
             </div>
         </div>
     }
+    @if (!string.IsNullOrWhiteSpace(Model.Transaction.ReversalOfTransactionId))
+    {
+        <div class="txn-detail-row">
+            <div class="txn-detail-label">
+                <span>Reversal Of</span>
+            </div>
+            <div class="txn-detail-result">
+                <span>
+                    <a asp-controller="Transactions"
+                       asp-action="Details"
+                       asp-route-team="@Model.Transaction.Source.Team.Slug"
+                       asp-route-id="@Model.Transaction.ReversalOfTransactionId">Click here to view reversed transaction</a>
+                </span>
+            </div>
+        </div>
+    }
+    @if (!string.IsNullOrWhiteSpace(Model.Transaction.ReversalTransactionId))
+    {
+        <div class="txn-detail-row">
+            <div class="txn-detail-label">
+                <span>Reversal Transaction</span>
+            </div>
+            <div class="txn-detail-result">
+                <span>
+                    <a asp-controller="Transactions"
+                       asp-action="Details"
+                       asp-route-team="@Model.Transaction.Source.Team.Slug"
+                       asp-route-id="@Model.Transaction.ReversalTransactionId">Click here to view reversal transaction</a>
+                </span>
+            </div>
+        </div>
+    }
     @if (Model.RelatedTransactions.Transactions.Any())
     {
         <div class="txn-detail-row">

--- a/Sloth.Web/Views/Transactions/_KfsDetails.cshtml
+++ b/Sloth.Web/Views/Transactions/_KfsDetails.cshtml
@@ -93,6 +93,38 @@
         </div>
     </div>
     }
+    @if (!string.IsNullOrWhiteSpace(Model.Transaction.ReversalOfTransactionId))
+    {
+        <div class="txn-detail-row">
+            <div class="txn-detail-label">
+                <span>Reversal Of</span>
+            </div>
+            <div class="txn-detail-result">
+                <span>
+                    <a asp-controller="Transactions"
+                       asp-action="Details"
+                       asp-route-team="@Model.Transaction.Source.Team.Slug"
+                       asp-route-id="@Model.Transaction.ReversalOfTransactionId">Click here to view reversed transaction</a>
+                </span>
+            </div>
+        </div>
+    }
+    @if (!string.IsNullOrWhiteSpace(Model.Transaction.ReversalTransactionId))
+    {
+        <div class="txn-detail-row">
+            <div class="txn-detail-label">
+                <span>Reversal Transaction</span>
+            </div>
+            <div class="txn-detail-result">
+                <span>
+                    <a asp-controller="Transactions"
+                       asp-action="Details"
+                       asp-route-team="@Model.Transaction.Source.Team.Slug"
+                       asp-route-id="@Model.Transaction.ReversalTransactionId">Click here to view reversal transaction</a>
+                </span>
+            </div>
+        </div>
+    }
     @if (Model.RelatedTransactions.Transactions.Any())
     {
         <div class="txn-detail-row">


### PR DESCRIPTION
Issue #369

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transaction detail pages now display reversal relationships. Users can view and navigate to both the original transaction being reversed and any corresponding reversal transaction. This enhancement improves visibility into transaction reversal chains and simplifies navigation between related transactions, providing better traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->